### PR TITLE
[frontend] fix label formatting fallback

### DIFF
--- a/frontend/src/modules/common/config/__tests__/chartConfig.test.js
+++ b/frontend/src/modules/common/config/__tests__/chartConfig.test.js
@@ -9,4 +9,13 @@ describe('formatChartLabels', () => {
     const labels = formatChartLabels(stats, 'monthly');
     expect(labels).toEqual(['Jan', 'Feb']);
   });
+
+  test('falls back to year/month fields', () => {
+    const stats = [
+      { year: '2024', month: '01' },
+      { year: '2024', month: '02' },
+    ];
+    const labels = formatChartLabels(stats, 'monthly');
+    expect(labels).toEqual(['Jan', 'Feb']);
+  });
 });

--- a/frontend/src/modules/common/config/chartConfig.js
+++ b/frontend/src/modules/common/config/chartConfig.js
@@ -108,7 +108,14 @@ export const formatChartLabels = (timeStats, granularity) => {
     // API returns a `period` field for all granularities. Older
     // versions exposed `year` and `month`, so fall back to those if
     // present for backwards compatibility.
-    const period = item.period ?? item.year ?? item.month;
+    let period = item.period;
+    if (!period && item.year && item.month) {
+      const year = String(item.year);
+      const month = String(item.month).padStart(2, "0");
+      period = `${year}-${month}`;
+    } else if (!period) {
+      period = item.year ?? item.month;
+    }
 
     if (granularity === "yearly") {
       return period;


### PR DESCRIPTION
## Summary
- improve label formatting fallback when only year and month fields are provided
- test the fallback logic in `formatChartLabels`

## Testing
- `npx react-scripts test --watchAll=false --passWithNoTests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829bcef08c832297be6e01a03b6837