### PR TITLE
[frontend] deduplicate color preference effect

### DIFF
--- a/frontend/src/modules/common/contexts/SettingsContext.js
+++ b/frontend/src/modules/common/contexts/SettingsContext.js
@@ -445,13 +445,6 @@ export const SettingsProvider = ({ children }) => {
 
   useEffect(() => {
     localStorage.setItem(
-      "impressionsOverTimeGraphColor",
-      impressionsOverTimeGraphColor,
-    );
-  }, [impressionsOverTimeGraphColor]);
-
-  useEffect(() => {
-    localStorage.setItem(
       "impressionRevenueOverTimeGraphColor",
       impressionRevenueOverTimeGraphColor,
     );


### PR DESCRIPTION
## Summary
- remove a duplicate `useEffect` for `impressionsOverTimeGraphColor`

## Testing
- `npm test -- --watchAll=false`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68829bcef08c832297be6e01a03b6837