### PR TITLE
[frontend] allow manual producer entry

### DIFF
--- a/backend/apps/payments/old_tests.py
+++ b/backend/apps/payments/old_tests.py
@@ -36,7 +36,11 @@ class PaymentRegressionTests(TestCase):
             "os.environ",
             {"STRIPE_PROFESSIONAL_PRICE_ID": "price_prof", "REACT_APP_URL": "http://x"},
         ):
-            session = StripeService.create_checkout_session(self.user, "professional", [addon])
+            session = StripeService.create_checkout_session(
+                self.user,
+                "professional",
+                [addon],
+            )
 
         self.assertEqual(session.id, "sess_1")
         mock_create.assert_called_once()

--- a/frontend/src/modules/management/api/producers.js
+++ b/frontend/src/modules/management/api/producers.js
@@ -26,6 +26,39 @@ export const uploadProducers = async (file) => {
   }
 };
 
+export const addProducer = async (data) => {
+  const token = localStorage.getItem("accessToken");
+
+  try {
+    const response = await fetch(
+      apiUrl + `/products/${data.product}/users`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer " + token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      },
+    );
+
+    const responseData = await response.json();
+
+    if (!response.ok) {
+      const message =
+        typeof responseData === "object"
+          ? Object.values(responseData).flat().join(" ")
+          : "Something went wrong";
+
+      throw new Error(message);
+    }
+
+    return { success: true, message: responseData };
+  } catch (error) {
+    return { success: false, message: error.message };
+  }
+};
+
 export const updateProducer = async (data, product_id, user_id) => {
   const token = localStorage.getItem("accessToken");
 

--- a/frontend/src/modules/management/components/AddProducerForm.jsx
+++ b/frontend/src/modules/management/components/AddProducerForm.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { addProducer } from "../api/producers";
+import { useProducts } from "../../products/api/products";
+import { getProjectMembers } from "../../projects/api/project";
+
+const AddProducerForm = () => {
+  const { products } = useProducts();
+  const [members, setMembers] = useState([]);
+  const [productId, setProductId] = useState("");
+  const [memberId, setMemberId] = useState("");
+  const [fee, setFee] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      try {
+        const data = await getProjectMembers();
+        setMembers(data);
+      } catch (error) {
+        toast.error("Failed to load project members");
+      }
+    };
+    fetchMembers();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!productId || !memberId || !fee) {
+      toast.error("Please fill in all fields");
+      return;
+    }
+
+    const payload = {
+      product: Number(productId),
+      user: Number(memberId),
+      producer_fee: Number(fee),
+    };
+    setLoading(true);
+    try {
+      const response = await addProducer(payload);
+      if (!response.success) {
+        toast.error(response.message || "Something went wrong");
+      } else {
+        toast.success("Successfully assigned producer");
+        window.location.reload();
+      }
+    } catch (err) {
+      toast.error(err.message || "Error assigning producer");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4">
+      <h5 className="mb-3">Add Producer Manually</h5>
+      <div className="row g-2">
+        <div className="col-md-4">
+          <select
+            className="form-control"
+            value={productId}
+            onChange={(e) => setProductId(e.target.value)}
+          >
+            <option value="">Select product</option>
+            {products?.map((product) => (
+              <option key={product.id} value={product.id}>
+                {product.title}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="col-md-4">
+          <select
+            className="form-control"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+          >
+            <option value="">Select member</option>
+            {members?.map((member) => (
+              <option
+                key={member.id}
+                value={member.user_details?.id || member.user_id}
+              >
+                {member.user_details?.email}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="col-md-2">
+          <input
+            type="number"
+            min={1}
+            max={100}
+            className="form-control"
+            placeholder="Fee %"
+            value={fee}
+            onChange={(e) => setFee(e.target.value)}
+          />
+        </div>
+        <div className="col-md-2">
+          <button type="submit" className="btn btn-primary w-100" disabled={loading}>
+            Add
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default AddProducerForm;

--- a/frontend/src/modules/management/pages/Producers.jsx
+++ b/frontend/src/modules/management/pages/Producers.jsx
@@ -3,6 +3,7 @@ import { toast } from "react-toastify";
 import PageHeader from "../../common/components/PageHeader";
 import { removeProducer, updateProducer } from "../api/producers";
 import ProducerUploadInput from "../components/ProducerUploadInput";
+import AddProducerForm from "../components/AddProducerForm";
 import { PersonXFill, Wrench } from "react-bootstrap-icons";
 import ModifyFeeModal from "../components/ModifyFeeModal";
 import { useProducts } from "../../products/api/products";
@@ -54,6 +55,7 @@ const Producers = () => {
       />
 
       <ProducerUploadInput />
+      <AddProducerForm />
 
       {products?.length > 0 && (
         <div className="mt-5">


### PR DESCRIPTION
## Summary
- allow manual producer addition with a new form
- support creating a producer via API
- render the form on the producer management page

## Testing
- `npm run lint`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6882cfbf51188322821c35f00d0526ee