### PR TITLE
[backend] replace weasyprint with wkhtmltopdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,9 @@ more thorough walkthrough.
    python -m venv venv
    source venv/bin/activate  # On Windows: venv\Scripts\activate
    pip install -r requirements.txt
-   # WeasyPrint relies on cairo and other system packages
-   # If you see "ModuleNotFoundError: weasyprint" install its dependencies:
-   # sudo apt-get install libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libcairo2
+   # wkhtmltopdf is required for PDF generation
+   # If it's missing, install the binary (Debian/Ubuntu):
+   # sudo apt-get install wkhtmltopdf
    python manage.py runserver
    ```
 

--- a/backend/apps/report/tasks.py
+++ b/backend/apps/report/tasks.py
@@ -1,12 +1,12 @@
 import uuid
 from datetime import datetime, time, timedelta
 
+import pdfkit
 from celery import shared_task
 from django.core.files.base import ContentFile
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.timezone import now
-import pdfkit
 
 from apps.analytics.utils import calculate_analytics
 from apps.emails.tasks import task_send_db_template_email

--- a/backend/apps/report/tasks.py
+++ b/backend/apps/report/tasks.py
@@ -6,7 +6,7 @@ from django.core.files.base import ContentFile
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.timezone import now
-from weasyprint import HTML
+import pdfkit
 
 from apps.analytics.utils import calculate_analytics
 from apps.emails.tasks import task_send_db_template_email
@@ -84,7 +84,7 @@ def generate_report_pdf(report_id, base_url=None):
     }
 
     html_content = render_to_string("report_template.html", context)
-    pdf_file = HTML(string=html_content).write_pdf()
+    pdf_file = pdfkit.from_string(html_content, False)
 
     filename = report.filename or f"rx_report_{uuid.uuid4().hex}.pdf"
     report.file.save(filename, ContentFile(pdf_file))

--- a/backend/apps/report/tests.py
+++ b/backend/apps/report/tests.py
@@ -386,8 +386,8 @@ class TestGenerateReportTask(TestCase):
         )
 
     @patch("apps.report.tasks.create_notification")
-    @patch("apps.report.tasks.HTML")
-    def test_generate_report_pdf(self, mock_html, mock_create_notification):
+    @patch("apps.report.tasks.pdfkit.from_string")
+    def test_generate_report_pdf(self, mock_from_string, mock_create_notification):
         report = Report.objects.create(
             filename="task.pdf",
             project=self.project,
@@ -395,16 +395,14 @@ class TestGenerateReportTask(TestCase):
             created_by=self.user,
         )
 
-        mock_html_instance = Mock()
-        mock_html_instance.write_pdf.return_value = b"pdf"
-        mock_html.return_value = mock_html_instance
+        mock_from_string.return_value = b"pdf"
 
         generate_report_pdf(report.id, "http://testserver/")
 
         report.refresh_from_db()
         self.assertIsNotNone(report.file)
         mock_create_notification.assert_called_once()
-        mock_html.assert_called_once()
+        mock_from_string.assert_called_once()
 
 
 class TestProcessReportSchedules(TestCase):

--- a/backend/apps/report/tests.py
+++ b/backend/apps/report/tests.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.contrib.auth import get_user_model

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ psycopg==3.2.4
 ruff==0.9.6
 drf-spectacular==0.28.0
 Pillow
-weasyprint==64.1
+pdfkit==1.0.0
 celery==5.5.3
 redis>=4.0
 django-celery-beat>=2.0

--- a/documentation/NON_DOCKER_SETUP.md
+++ b/documentation/NON_DOCKER_SETUP.md
@@ -45,10 +45,9 @@ python -m venv venv
 source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 pip install -r requirements.txt
 
-# WeasyPrint depends on additional system packages like cairo and pango.
-# If you encounter "ModuleNotFoundError: weasyprint" after installing
-# Python requirements, install the OS dependencies. On Debian/Ubuntu:
-# sudo apt-get install libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libcairo2
+# wkhtmltopdf is required for PDF generation.
+# If it's missing, install the binary. On Debian/Ubuntu:
+# sudo apt-get install wkhtmltopdf
 ```
 
 ## 5. Run migrations and start the backend


### PR DESCRIPTION
## Summary
- switch PDF generation to `pdfkit` + `wkhtmltopdf`
- update tests for new pdfkit usage
- document wkhtmltopdf requirement

## Testing
- `python manage.py migrate --noinput`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6882db3ecfa48322aec720a25d82bd01