### PR TITLE
[royaltyx] Add health check endpoint and tests

### DIFF
--- a/backend/common/tests/test_health.py
+++ b/backend/common/tests/test_health.py
@@ -1,0 +1,13 @@
+from django.urls import reverse
+from rest_framework.test import APIClient
+from django.test import TestCase
+
+
+class HealthEndpointTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_health_endpoint_returns_ok(self):
+        response = self.client.get(reverse("health"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})

--- a/backend/common/urls.py
+++ b/backend/common/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import health
+
+urlpatterns = [
+    path('health/', health, name='health'),
+]

--- a/backend/common/views.py
+++ b/backend/common/views.py
@@ -1,0 +1,7 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+@api_view(["GET"])
+def health(request):
+    """Simple health check endpoint."""
+    return Response({"status": "ok"})

--- a/backend/royaltyx/urls.py
+++ b/backend/royaltyx/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("payments/", include("apps.payments.urls")),
     path("emails/", include("apps.emails.urls")),
     path("fees/", include("apps.fees.urls")),
+    path("", include("common.urls")),
     ## OAuth2
     path("oauth/google/", include("apps.oauth.google.urls")),
     path("oauth/tiktok/", include("apps.oauth.tiktok.urls")),

--- a/frontend/src/modules/common/api/__tests__/health.test.js
+++ b/frontend/src/modules/common/api/__tests__/health.test.js
@@ -1,0 +1,16 @@
+describe("getHealthStatus", () => {
+  test("calls backend health endpoint and returns data", async () => {
+    process.env.REACT_APP_API_URL = "http://localhost:8000";
+    jest.resetModules();
+    const { getHealthStatus } = require("../health");
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ status: "ok" }),
+      }),
+    );
+    const data = await getHealthStatus();
+    expect(fetch).toHaveBeenCalledWith("http://localhost:8000/health/");
+    expect(data).toEqual({ status: "ok" });
+  });
+});

--- a/frontend/src/modules/common/api/health.js
+++ b/frontend/src/modules/common/api/health.js
@@ -1,0 +1,9 @@
+import { apiUrl } from "./config";
+
+export const getHealthStatus = async () => {
+  const response = await fetch(`${apiUrl}/health/`);
+  if (!response.ok) {
+    throw new Error("Health check failed");
+  }
+  return response.json();
+};


### PR DESCRIPTION
## Summary
- implement simple `/health/` endpoint in backend
- expose API function in frontend for checking backend health
- add tests for new endpoint and API wrapper

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint`
- `npx prettier --check src/modules/common/api/health.js src/modules/common/api/__tests__/health.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6882e5930bcc832284f91b55e771e528