### PR TITLE
[backend] fix single-period analytics

### DIFF
--- a/backend/apps/analytics/tests.py
+++ b/backend/apps/analytics/tests.py
@@ -500,6 +500,32 @@ class AnalyticsUtilsOutputTests(TestCase):
         self.assertTrue(stats)
         self.assertIn("period", stats[0])
 
+    def test_monthly_stats_single_month(self):
+        from apps.analytics.utils import calculate_monthly_stats
+
+        end = datetime(2024, 3, 31)
+        stats = calculate_monthly_stats(
+            ProductImpressions.objects.none(),
+            ProductSale.objects.none(),
+            1,
+            end,
+        )
+        self.assertEqual(len(stats), 1)
+        self.assertEqual(stats[0]["period"], "2024-03")
+
+    def test_yearly_stats_single_year(self):
+        from apps.analytics.utils import calculate_yearly_stats
+
+        end = datetime(2024, 12, 31)
+        stats = calculate_yearly_stats(
+            ProductImpressions.objects.none(),
+            ProductSale.objects.none(),
+            1,
+            end,
+        )
+        self.assertEqual(len(stats), 1)
+        self.assertEqual(stats[0]["period"], "2024")
+
     def test_calculate_analytics_monthly_uses_given_end_date(self):
         project = Project.objects.create(name="P", description="d")
         from apps.analytics.utils import calculate_analytics

--- a/backend/apps/analytics/utils.py
+++ b/backend/apps/analytics/utils.py
@@ -78,10 +78,6 @@ def calculate_yearly_stats(
     rentals_map = {entry["year"]: entry["count"] for entry in yearly_rentals}
 
     yearly_stats = []
-    single_year_adjustment = False
-    if years == 1:
-        years += 1
-        single_year_adjustment = True
 
     for i in range(years):
         if period_end:
@@ -97,8 +93,6 @@ def calculate_yearly_stats(
                 .date()
             )
 
-        if single_year_adjustment:
-            year_date = (year_date + timedelta(days=365)).replace(month=1, day=1)
 
         yearly_stats.append(
             {
@@ -185,10 +179,6 @@ def calculate_monthly_stats(
     rentals_map = {entry["month"]: entry["count"] for entry in monthly_rentals}
 
     monthly_stats = []
-    single_month_adjustment = False
-    if months == 1:
-        months += 1
-        single_month_adjustment = True
 
     if period_end and isinstance(period_end, datetime):
         end_date = period_end.date()
@@ -206,8 +196,6 @@ def calculate_monthly_stats(
                 now.date().replace(day=1) - timedelta(days=i * 30)
             ).replace(day=1)
 
-        if single_month_adjustment:
-            month_date = (month_date + timedelta(days=31)).replace(day=1)
 
         monthly_stats.append(
             {


### PR DESCRIPTION
## Summary
- handle single-period analytics correctly
- cover single month and single year cases in tests

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6882fdc0690c8322b80d3f64c9163389