### PR TITLE
[royaltyx] Clean pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 python_files = apps/*/tests/*.py apps/*/old_tests.py
 
-# Use our Django settings module for tests
-DJANGO_SETTINGS_MODULE = backend.royaltyx.test_settings
+# The Django environment is configured in conftest.py so we disable the pytest
+# django plugin. Removing the DJANGO_SETTINGS_MODULE option avoids a config
+# warning when running tests with -p no:django.
 addopts = -p no:django


### PR DESCRIPTION
## Summary
- silence pytest config warning by removing `DJANGO_SETTINGS_MODULE` from pytest.ini

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6882fdad75e48322ab226b104b7ee52e