### PR TITLE
[backend] fix yearly analytics calculation

### DIFF
--- a/backend/apps/analytics/tests.py
+++ b/backend/apps/analytics/tests.py
@@ -500,6 +500,17 @@ class AnalyticsUtilsOutputTests(TestCase):
         self.assertTrue(stats)
         self.assertIn("period", stats[0])
 
+    def test_single_year_range_returns_single_entry(self):
+        from apps.analytics.utils import calculate_yearly_stats
+        stats = calculate_yearly_stats(
+            ProductImpressions.objects.none(),
+            ProductSale.objects.none(),
+            1,
+            date(2024, 12, 31),
+        )
+        self.assertEqual(len(stats), 1)
+        self.assertEqual(stats[0]["period"], "2024")
+
     def test_calculate_analytics_monthly_uses_given_end_date(self):
         project = Project.objects.create(name="P", description="d")
         from apps.analytics.utils import calculate_analytics

--- a/backend/apps/analytics/utils.py
+++ b/backend/apps/analytics/utils.py
@@ -78,27 +78,24 @@ def calculate_yearly_stats(
     rentals_map = {entry["year"]: entry["count"] for entry in yearly_rentals}
 
     yearly_stats = []
-    single_year_adjustment = False
-    if years == 1:
-        years += 1
-        single_year_adjustment = True
+
+    if period_end and isinstance(period_end, datetime):
+        end_date = period_end.date()
+    else:
+        end_date = period_end
 
     for i in range(years):
-        if period_end:
+        if end_date:
             year_date = (
-                (period_end.replace(month=1, day=1) - timedelta(days=i * 365))
+                (end_date.replace(month=1, day=1) - timedelta(days=i * 365))
                 .replace(month=1, day=1)
-                .date()
             )
         else:
             year_date = (
                 (now.replace(month=1, day=1) - timedelta(days=i * 365))
                 .replace(month=1, day=1)
-                .date()
-            )
+            ).date()
 
-        if single_year_adjustment:
-            year_date = (year_date + timedelta(days=365)).replace(month=1, day=1)
 
         yearly_stats.append(
             {
@@ -185,10 +182,6 @@ def calculate_monthly_stats(
     rentals_map = {entry["month"]: entry["count"] for entry in monthly_rentals}
 
     monthly_stats = []
-    single_month_adjustment = False
-    if months == 1:
-        months += 1
-        single_month_adjustment = True
 
     if period_end and isinstance(period_end, datetime):
         end_date = period_end.date()
@@ -206,8 +199,6 @@ def calculate_monthly_stats(
                 now.date().replace(day=1) - timedelta(days=i * 30)
             ).replace(day=1)
 
-        if single_month_adjustment:
-            month_date = (month_date + timedelta(days=31)).replace(day=1)
 
         monthly_stats.append(
             {


### PR DESCRIPTION
## Summary
- fix yearly stats calculation logic when a single year is requested
- simplify monthly stats and yearly stats loops
- add regression test for single-year ranges

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882fdc0690c8322b80d3f64c9163389