### PR TITLE
[docs] expand docs and add backend app reference

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -23,7 +23,8 @@ RoyaltyX/
 
 ### Backend Apps
 
-The `backend/apps` folder contains Django apps for different domains:
+The `backend/apps` folder contains Django apps for different domains. See
+[Backend App Reference](documentation/BACKEND_APPS.md) for a complete list.
 
 - **authentication** – JWT auth endpoints and OAuth logic
 - **user** – user profiles and subscription plans
@@ -32,8 +33,11 @@ The `backend/apps` folder contains Django apps for different domains:
 - **sources** – management of revenue sources such as YouTube
 - **report** – PDF report generation and scheduling
 - **emails** – templated email sending via Celery
+- **support** – in‑app help desk and FAQ system
+- **fees** – flexible fee rules applied to revenue events
 
-Each app has its own models, serializers, views and tests. Celery tasks live alongside the apps to keep the logic close to the models they act on.
+Each app has its own models, serializers, views and tests. Celery tasks live
+alongside the apps to keep the business logic near the models it acts on.
 
 ### Frontend
 
@@ -49,4 +53,7 @@ Backend tests run with Django's test runner. Frontend tests run via `react-scrip
 
 ## Related Documentation
 
-Additional guides live in the `documentation/` directory and as Markdown files in the repository root. See [README.md](README.md) for setup instructions, payment integration details and more.
+Additional guides live in the `documentation/` directory and as Markdown files
+in the repository root. See [README.md](README.md) for setup instructions,
+payment integration details and more. A detailed listing of Django apps is
+available in [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).

--- a/README.md
+++ b/README.md
@@ -377,7 +377,8 @@ docker-compose -f local.yml up -d postgres
 ## 📁 Project Structure
 
 For a high level walkthrough of the repository layout see
-[CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md).
+[CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). For details on individual Django
+apps check [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
 
 ```
 RoyaltyX/

--- a/documentation/ANALYTICS_OVERVIEW.md
+++ b/documentation/ANALYTICS_OVERVIEW.md
@@ -14,3 +14,7 @@ RoyaltyX stores raw sales and impression data and calculates aggregated metrics 
 - Per-source analytics created by `calculate_analytics_per_source`.
 
 These values are computed at request time to keep the database lightweight and ensure the dashboard always reflects the latest data.
+
+For a deep dive into how data is imported see
+[MANUAL_DATA_UPLOAD.md](MANUAL_DATA_UPLOAD.md).
+

--- a/documentation/BACKEND_APPS.md
+++ b/documentation/BACKEND_APPS.md
@@ -1,0 +1,25 @@
+# Backend App Reference
+
+This document lists the Django apps included in the `backend/apps` directory and briefly describes what each one does.
+
+| App | Purpose |
+| --- | ------- |
+| **admin_panel** | Minimal custom views for the Django admin dashboard. |
+| **analytics** | Aggregates sales and impression data for charts and tables. |
+| **authentication** | JWT login endpoints and optional OAuth helpers. |
+| **data_imports** | Handles CSV/XLSX uploads and import templates. |
+| **emails** | Manages templated email sending through Celery tasks. |
+| **fees** | Defines project specific fees and calculates adjustments. |
+| **inbox** | Notification inbox for system alerts. |
+| **notifications** | Banner and email notifications for events. |
+| **oauth** | OAuth client logic for third‑party integrations. |
+| **payments** | Stripe integration and webhook processing. |
+| **product** | Product catalogue models and API endpoints. |
+| **project** | Core project management models and permissions. |
+| **report** | PDF report generation and template management. |
+| **sources** | Syncs data from external platforms such as YouTube. |
+| **support** | Help desk tickets and public FAQ articles. |
+| **user** | Custom user model and subscription plans. |
+
+Each app contains its own models, serializers, views and tests. Celery tasks live alongside the apps to keep the business logic close to the models they act on.
+

--- a/documentation/DEVELOPER_GUIDE.md
+++ b/documentation/DEVELOPER_GUIDE.md
@@ -23,3 +23,14 @@ cd backend && python manage.py test
 cd frontend && npm test -- --watchAll=false
 ```
 
+## Helpful Scripts
+
+The `scripts/` directory contains small utilities used during deployment.
+`update-domain.sh` rewrites Nginx configs and `.env` values when you move the
+application to a custom domain:
+
+```bash
+./scripts/update-domain.sh yourdomain.com
+```
+
+

--- a/documentation/MANUAL_DATA_UPLOAD.md
+++ b/documentation/MANUAL_DATA_UPLOAD.md
@@ -37,4 +37,7 @@ If processing fails due to missing columns, you can supply a JSON mapping to cor
 
 ## Analytics and Reports
 Successful uploads create `ProductSale` and `ProductImpressions` records. Analytics pages and PDF reports aggregate these records on demand, so new data becomes visible as soon as processing completes.
+For an overview of how fees are applied to revenue see
+[FEE_SYSTEM.md](FEE_SYSTEM.md).
+
 

--- a/documentation/NON_DOCKER_SETUP.md
+++ b/documentation/NON_DOCKER_SETUP.md
@@ -1,6 +1,7 @@
 # Running RoyaltyX Without Docker
 
 This guide explains how to run the backend and frontend directly on your machine without Docker.
+See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for tips on linting and running tests.
 
 ## Prerequisites
 
@@ -80,4 +81,5 @@ celery -A royaltyx worker -B --loglevel=info
 ```
 
 You're now running RoyaltyX without Docker.
+
 


### PR DESCRIPTION
## Summary
- document each Django app in a new BACKEND_APPS guide
- link the new guide from README and CODEBASE_OVERVIEW
- mention helpful scripts in Developer Guide
- cross reference other docs for clarity

## Testing
- `pytest -q`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688312d570e48322b05e3dc35af36f4e