### PR TITLE
[docs] add support system overview

### DIFF
--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -32,6 +32,7 @@ The `backend/apps` folder contains Django apps for different domains:
 - **sources** – management of revenue sources such as YouTube
 - **report** – PDF report generation and scheduling
 - **emails** – templated email sending via Celery
+- **support** – ticketing system and AI help chat
 
 Each app has its own models, serializers, views and tests. Celery tasks live alongside the apps to keep the logic close to the models they act on.
 

--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 📞 Support
 
 - **Documentation**: Check our comprehensive docs
+- **Support System**: See [Support System Overview](documentation/SUPPORT_OVERVIEW.md) for ticket and help chat endpoints
 - **AI Help Chat**: Use the built-in chat at `/admin/documentation/chat` for quick tips
 - **Issues**: Report bugs on GitHub Issues
 - **Email**: support@royaltyx.com

--- a/documentation/API_OVERVIEW.md
+++ b/documentation/API_OVERVIEW.md
@@ -35,3 +35,12 @@ This document lists the primary REST endpoints exposed by RoyaltyX. The complete
 - `POST /emails/templates/` – Create a new template
 - `GET  /emails/templates/{id}/` – Retrieve, update or delete a template
 - `POST /emails/templates/generate/` – Generate a template with OpenAI
+
+## Support
+- `GET  /support/tickets/` – List the current user's tickets
+- `POST /support/tickets/` – Create a new ticket
+- `GET  /support/tickets/{id}/` – Retrieve or update a ticket
+- `POST /support/tickets/{id}/messages/` – Add a message to a ticket
+- `GET  /support/stats/` – Ticket stats for the current user
+- `GET  /support/help/chat/` – AI-powered help chat
+

--- a/documentation/SUPPORT_OVERVIEW.md
+++ b/documentation/SUPPORT_OVERVIEW.md
@@ -1,0 +1,31 @@
+# Support System Overview
+
+RoyaltyX includes a built‑in support ticket workflow and an AI‑powered help chat to assist users. This document summarizes the available features and REST endpoints.
+
+## Support Tickets
+
+Authenticated users can open support tickets to contact the team. Each ticket stores a conversation thread.
+
+### Customer Endpoints
+
+- `GET  /support/tickets/` – list the user's tickets
+- `POST /support/tickets/` – create a new ticket
+- `GET  /support/tickets/{id}/` – retrieve or update a ticket
+- `POST /support/tickets/{id}/messages/` – add a message to the ticket
+- `GET  /support/stats/` – summary counts for the logged‑in user
+
+### Admin Endpoints
+
+- `GET  /support/admin/tickets/` – list all tickets
+- `GET  /support/admin/tickets/{id}/` – retrieve or update any ticket
+- `POST /support/admin/tickets/{id}/assign/` – assign a ticket to a staff member
+- `POST /support/admin/tickets/{id}/take/` – self‑assign the ticket
+- `GET  /support/admin/stats/` – dashboard statistics
+
+## Help Chat
+
+The endpoint `POST /support/help/chat/` provides a lightweight OpenAI chat interface. Messages are stored in persistent threads so users and staff can continue a conversation over time.
+
+Include `OPENAI_API_KEY` in your environment for this feature.
+
+


### PR DESCRIPTION
## Summary
- document support endpoints and OpenAI help chat
- link new guide from README
- expand CODEBASE_OVERVIEW backend app list
- extend API overview with support routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688312d570e48322b05e3dc35af36f4e