### PR TITLE
[frontend] add graph view options and advanced color picker

### DIFF
--- a/frontend/src/modules/analytics/components/GraphColorPalette.jsx
+++ b/frontend/src/modules/analytics/components/GraphColorPalette.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -7,6 +8,8 @@ import {
   Box,
   Grid,
   useTheme,
+  TextField,
+  Button,
 } from "@mui/material";
 import { X } from "lucide-react";
 
@@ -16,6 +19,7 @@ export const GraphColorPalette = ({
   onSelectColor,
 }) => {
   const theme = useTheme();
+  const [customColor, setCustomColor] = useState("#009efd");
   const baseColors = [
     "#6CC3E0",
     "#009efd",
@@ -115,6 +119,30 @@ export const GraphColorPalette = ({
             </Grid>
           ))}
         </Grid>
+        <Box sx={{ display: "flex", alignItems: "center", mt: 2, gap: 2 }}>
+          <TextField
+            type="color"
+            value={customColor}
+            onChange={(e) => setCustomColor(e.target.value)}
+            sx={{ width: 60, p: 0 }}
+          />
+          <TextField
+            label="Hex"
+            value={customColor}
+            onChange={(e) => setCustomColor(e.target.value)}
+            sx={{ width: 100 }}
+          />
+          <Button
+            variant="contained"
+            size="small"
+            onClick={() => {
+              onSelectColor(customColor);
+              setShowGraphColorPalette(false);
+            }}
+          >
+            Apply
+          </Button>
+        </Box>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/modules/analytics/components/GraphTypeSelector.jsx
+++ b/frontend/src/modules/analytics/components/GraphTypeSelector.jsx
@@ -5,6 +5,7 @@ const GRAPH_TYPES = [
   { id: "line", label: "Line" },
   { id: "bar", label: "Bar" },
   { id: "sharp", label: "Sharp line" },
+  { id: "pie", label: "Pie" },
 ];
 
 export const GraphTypeSelector = ({ open, onClose, onSelectType }) => {

--- a/frontend/src/modules/analytics/components/ImpressionRevenueOverTime.jsx
+++ b/frontend/src/modules/analytics/components/ImpressionRevenueOverTime.jsx
@@ -1,4 +1,4 @@
-import { Line } from "react-chartjs-2";
+import { Line, Bar } from "react-chartjs-2";
 import { useState } from "react";
 import { EyeSlash, Palette } from "react-bootstrap-icons";
 import { useSettings } from "../../common/contexts/SettingsContext";
@@ -13,10 +13,13 @@ import {
   Card,
   CardContent,
 } from "@mui/material";
-import { EllipsisVertical } from "lucide-react";
+import { EllipsisVertical, BarChart2 } from "lucide-react";
+import GraphTypeSelector from "./GraphTypeSelector";
 import {
   getBaseLineChartOptions,
   getBaseLineDataset,
+  getSharpLineDataset,
+  getBaseBarDataset,
   formatChartLabels,
   getChartTitle,
   CHART_CONFIGS,
@@ -26,6 +29,8 @@ const ImpressionRevenueOverTime = ({ analytics }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const { setShowImpressionRevenueOverTime } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
+  const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [graphType, setGraphType] = useState("line");
   const {
     setImpressionRevenueOverTimeGraphColor,
     impressionRevenueOverTimeGraphColor,
@@ -54,19 +59,22 @@ const ImpressionRevenueOverTime = ({ analytics }) => {
     (item) => item.impression_revenue
   );
   const chartTitle = getChartTitle("impression_revenue", granularity);
+  const datasetFn =
+    graphType === "sharp"
+      ? getSharpLineDataset
+      : graphType === "bar"
+      ? getBaseBarDataset
+      : getBaseLineDataset;
 
   const data = {
     labels,
     datasets: [
-      getBaseLineDataset(
-        chartTitle,
-        dataValues,
-        impressionRevenueOverTimeGraphColor
-      ),
+      datasetFn(chartTitle, dataValues, impressionRevenueOverTimeGraphColor),
     ],
   };
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.currency);
+  const ChartComponent = graphType === "bar" ? Bar : Line;
 
   return (
     <>
@@ -121,15 +129,25 @@ const ImpressionRevenueOverTime = ({ analytics }) => {
                       Hide
                     </MenuItem>
                     <MenuItem
-                      onClick={() => {
-                        setShowGraphColorPalette(true);
-                        handleMenuClose();
-                      }}
-                      sx={{ py: 1 }}
-                    >
-                      <Palette style={{ marginRight: 8 }} />
-                      Customize color
-                    </MenuItem>
+                    onClick={() => {
+                      setShowGraphColorPalette(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <Palette style={{ marginRight: 8 }} />
+                    Customize color
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      setShowGraphTypeSelector(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <BarChart2 style={{ marginRight: 8 }} />
+                    Graph type
+                  </MenuItem>
                   </Menu>
                 </Box>
               </Box>
@@ -148,7 +166,7 @@ const ImpressionRevenueOverTime = ({ analytics }) => {
                 </Typography>
               </Box>
               
-              <Line data={data} options={options} />
+              <ChartComponent data={data} options={options} />
             </Box>
           </CardContent>
         </Card>
@@ -158,6 +176,14 @@ const ImpressionRevenueOverTime = ({ analytics }) => {
         showGraphColorPalette={showGraphColorPalette}
         setShowGraphColorPalette={setShowGraphColorPalette}
         onSelectColor={onSelectColor}
+      />
+      <GraphTypeSelector
+        open={showGraphTypeSelector}
+        onClose={() => setShowGraphTypeSelector(false)}
+        onSelectType={(type) => {
+          setGraphType(type);
+          setShowGraphTypeSelector(false);
+        }}
       />
     </>
   );

--- a/frontend/src/modules/analytics/components/ImpressionsCard.jsx
+++ b/frontend/src/modules/analytics/components/ImpressionsCard.jsx
@@ -16,7 +16,7 @@ import {
   MenuItem,
   Button,
 } from "@mui/material";
-import { EllipsisVertical, ArrowRight, BarChart2, Type } from "lucide-react";
+import { EllipsisVertical, ArrowRight, BarChart2, Type, List } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 export const ImpressionsCard = ({
@@ -29,6 +29,7 @@ export const ImpressionsCard = ({
   const { setShowTotalImpressionsCard } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
   const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [showChart, setShowChart] = useState(true);
   const {
     setimpressionsGraphColor,
     setImpressionsGraphType,
@@ -139,6 +140,16 @@ export const ImpressionsCard = ({
                   </MenuItem>
                   <MenuItem
                     onClick={() => {
+                      setShowChart(!showChart);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <List style={{ marginRight: 8 }} />
+                    {showChart ? "Numeric only" : "Show chart"}
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
                       setImpressionsValueFormat(
                         impressionsValueFormat === "currency" ? "number" : "currency"
                       );
@@ -158,7 +169,7 @@ export const ImpressionsCard = ({
                 : analytics?.total_impressions.toLocaleString()}
             </Typography>
 
-            <ImpressionsChart analytics={analytics} />
+            {showChart && <ImpressionsChart analytics={analytics} />}
 
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
               <Button

--- a/frontend/src/modules/analytics/components/ImpressionsChart.jsx
+++ b/frontend/src/modules/analytics/components/ImpressionsChart.jsx
@@ -1,4 +1,4 @@
-import { Line, Bar } from "react-chartjs-2";
+import { Line, Bar, Pie } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -18,6 +18,7 @@ import {
   getBaseLineDataset,
   getSharpLineDataset,
   getBaseBarDataset,
+  getBasePieDataset,
   formatChartLabels,
   getChartTitle
 } from "../../common/config/chartConfig";
@@ -50,6 +51,9 @@ export const ImpressionsChart = ({ analytics }) => {
       ? getSharpLineDataset
       : impressionsGraphType === "bar"
       ? getBaseBarDataset
+      : impressionsGraphType === "pie"
+      ? (label, data) =>
+          getBasePieDataset(label, data, data.map(() => impressionsGraphColor))
       : getBaseLineDataset;
 
   const data = {
@@ -59,7 +63,12 @@ export const ImpressionsChart = ({ analytics }) => {
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.standard);
 
-  const ChartComponent = impressionsGraphType === "bar" ? Bar : Line;
+  const ChartComponent =
+    impressionsGraphType === "bar"
+      ? Bar
+      : impressionsGraphType === "pie"
+      ? Pie
+      : Line;
 
   return (
     <div style={{ width: "100%", maxWidth: "700px", margin: "auto" }}>

--- a/frontend/src/modules/analytics/components/ImpressionsOverTime.jsx
+++ b/frontend/src/modules/analytics/components/ImpressionsOverTime.jsx
@@ -1,4 +1,4 @@
-import { Line } from "react-chartjs-2";
+import { Line, Bar } from "react-chartjs-2";
 import { useState } from "react";
 import { EyeSlash, Palette } from "react-bootstrap-icons";
 import { useSettings } from "../../common/contexts/SettingsContext";
@@ -13,10 +13,13 @@ import {
   Card,
   CardContent,
 } from "@mui/material";
-import { EllipsisVertical } from "lucide-react";
+import { EllipsisVertical, BarChart2 } from "lucide-react";
+import GraphTypeSelector from "./GraphTypeSelector";
 import {
   getBaseLineChartOptions,
   getBaseLineDataset,
+  getSharpLineDataset,
+  getBaseBarDataset,
   formatChartLabels,
   getChartTitle,
   CHART_CONFIGS,
@@ -26,6 +29,8 @@ const ImpressionsOverTime = ({ analytics }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const { setShowImpressionsOverTime } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
+  const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [graphType, setGraphType] = useState("line");
   const { setImpressionsOverTimeGraphColor, impressionsOverTimeGraphColor } =
     useSettings();
 
@@ -50,15 +55,20 @@ const ImpressionsOverTime = ({ analytics }) => {
   const labels = formatChartLabels(impressionsData, granularity);
   const dataValues = impressionsData.map((item) => item.impressions);
   const chartTitle = getChartTitle("impressions", granularity);
+  const datasetFn =
+    graphType === "sharp"
+      ? getSharpLineDataset
+      : graphType === "bar"
+      ? getBaseBarDataset
+      : getBaseLineDataset;
 
   const data = {
     labels,
-    datasets: [
-      getBaseLineDataset(chartTitle, dataValues, impressionsOverTimeGraphColor),
-    ],
+    datasets: [datasetFn(chartTitle, dataValues, impressionsOverTimeGraphColor)],
   };
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.standard);
+  const ChartComponent = graphType === "bar" ? Bar : Line;
 
   return (
     <>
@@ -113,15 +123,25 @@ const ImpressionsOverTime = ({ analytics }) => {
                       Hide
                     </MenuItem>
                     <MenuItem
-                      onClick={() => {
-                        setShowGraphColorPalette(true);
-                        handleMenuClose();
-                      }}
-                      sx={{ py: 1 }}
-                    >
-                      <Palette style={{ marginRight: 8 }} />
-                      Customize color
-                    </MenuItem>
+                    onClick={() => {
+                      setShowGraphColorPalette(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <Palette style={{ marginRight: 8 }} />
+                    Customize color
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      setShowGraphTypeSelector(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <BarChart2 style={{ marginRight: 8 }} />
+                    Graph type
+                  </MenuItem>
                   </Menu>
                 </Box>
               </Box>
@@ -140,7 +160,7 @@ const ImpressionsOverTime = ({ analytics }) => {
                 </Typography>
               </Box>
               
-              <Line data={data} options={options} />
+              <ChartComponent data={data} options={options} />
             </Box>
           </CardContent>
         </Card>
@@ -149,6 +169,14 @@ const ImpressionsOverTime = ({ analytics }) => {
         showGraphColorPalette={showGraphColorPalette}
         setShowGraphColorPalette={setShowGraphColorPalette}
         onSelectColor={onSelectColor}
+      />
+      <GraphTypeSelector
+        open={showGraphTypeSelector}
+        onClose={() => setShowGraphTypeSelector(false)}
+        onSelectType={(type) => {
+          setGraphType(type);
+          setShowGraphTypeSelector(false);
+        }}
       />
     </>
   );

--- a/frontend/src/modules/analytics/components/RentalsOverTime.jsx
+++ b/frontend/src/modules/analytics/components/RentalsOverTime.jsx
@@ -1,4 +1,4 @@
-import { Line } from "react-chartjs-2";
+import { Line, Bar } from "react-chartjs-2";
 import { useState } from "react";
 import { EyeSlash, Palette } from "react-bootstrap-icons";
 import { useSettings } from "../../common/contexts/SettingsContext";
@@ -13,10 +13,13 @@ import {
   Card,
   CardContent,
 } from "@mui/material";
-import { EllipsisVertical } from "lucide-react";
+import { EllipsisVertical, BarChart2 } from "lucide-react";
+import GraphTypeSelector from "./GraphTypeSelector";
 import {
   getBaseLineChartOptions,
   getBaseLineDataset,
+  getSharpLineDataset,
+  getBaseBarDataset,
   formatChartLabels,
   getChartTitle,
   CHART_CONFIGS,
@@ -26,6 +29,8 @@ const RentalsOverTime = ({ analytics }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const { setShowRentalsOverTime } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
+  const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [graphType, setGraphType] = useState("line");
   const { setRentalsOverTimeGraphColor, rentalsOverTimeGraphColor } =
     useSettings();
 
@@ -50,15 +55,20 @@ const RentalsOverTime = ({ analytics }) => {
   const labels = formatChartLabels(rentalsData, granularity);
   const dataValues = rentalsData.map((item) => item.rentals);
   const chartTitle = getChartTitle("rentals", granularity);
+  const datasetFn =
+    graphType === "sharp"
+      ? getSharpLineDataset
+      : graphType === "bar"
+      ? getBaseBarDataset
+      : getBaseLineDataset;
 
   const data = {
     labels,
-    datasets: [
-      getBaseLineDataset(chartTitle, dataValues, rentalsOverTimeGraphColor),
-    ],
+    datasets: [datasetFn(chartTitle, dataValues, rentalsOverTimeGraphColor)],
   };
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.standard);
+  const ChartComponent = graphType === "bar" ? Bar : Line;
 
   return (
     <>
@@ -113,15 +123,25 @@ const RentalsOverTime = ({ analytics }) => {
                       Hide
                     </MenuItem>
                     <MenuItem
-                      onClick={() => {
-                        setShowGraphColorPalette(true);
-                        handleMenuClose();
-                      }}
-                      sx={{ py: 1 }}
-                    >
-                      <Palette style={{ marginRight: 8 }} />
-                      Customize color
-                    </MenuItem>
+                    onClick={() => {
+                      setShowGraphColorPalette(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <Palette style={{ marginRight: 8 }} />
+                    Customize color
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      setShowGraphTypeSelector(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <BarChart2 style={{ marginRight: 8 }} />
+                    Graph type
+                  </MenuItem>
                   </Menu>
                 </Box>
               </Box>
@@ -140,7 +160,7 @@ const RentalsOverTime = ({ analytics }) => {
                 </Typography>
               </Box>
               
-              <Line data={data} options={options} />
+              <ChartComponent data={data} options={options} />
             </Box>
           </CardContent>
         </Card>
@@ -149,6 +169,14 @@ const RentalsOverTime = ({ analytics }) => {
         showGraphColorPalette={showGraphColorPalette}
         setShowGraphColorPalette={setShowGraphColorPalette}
         onSelectColor={onSelectColor}
+      />
+      <GraphTypeSelector
+        open={showGraphTypeSelector}
+        onClose={() => setShowGraphTypeSelector(false)}
+        onSelectType={(type) => {
+          setGraphType(type);
+          setShowGraphTypeSelector(false);
+        }}
       />
     </>
   );

--- a/frontend/src/modules/analytics/components/RevenueCard.jsx
+++ b/frontend/src/modules/analytics/components/RevenueCard.jsx
@@ -16,7 +16,7 @@ import {
   MenuItem,
   Button,
 } from "@mui/material";
-import { EllipsisVertical, ArrowRight, BarChart2, Type } from "lucide-react";
+import { EllipsisVertical, ArrowRight, BarChart2, Type, List } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 export const RevenueCard = ({
@@ -29,6 +29,7 @@ export const RevenueCard = ({
   const { setShowTotalRevenueCard } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
   const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [showChart, setShowChart] = useState(true);
   const {
     setrevenueGraphColor,
     setRevenueGraphType,
@@ -138,6 +139,16 @@ export const RevenueCard = ({
                   </MenuItem>
                   <MenuItem
                     onClick={() => {
+                      setShowChart(!showChart);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <List style={{ marginRight: 8 }} />
+                    {showChart ? "Numeric only" : "Show chart"}
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
                       setRevenueValueFormat(
                         revenueValueFormat === "currency" ? "number" : "currency"
                       );
@@ -159,7 +170,7 @@ export const RevenueCard = ({
               </Typography>
             </Box>
 
-            <RevenueChart analytics={analytics} />
+            {showChart && <RevenueChart analytics={analytics} />}
 
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
               <Button

--- a/frontend/src/modules/analytics/components/RevenueChart.jsx
+++ b/frontend/src/modules/analytics/components/RevenueChart.jsx
@@ -1,4 +1,4 @@
-import { Line, Bar } from "react-chartjs-2";
+import { Line, Bar, Pie } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -18,6 +18,7 @@ import {
   getBaseLineDataset,
   getSharpLineDataset,
   getBaseBarDataset,
+  getBasePieDataset,
   formatChartLabels,
   getChartTitle,
 } from "../../common/config/chartConfig";
@@ -51,6 +52,9 @@ export const RevenueChart = ({ analytics }) => {
       ? getSharpLineDataset
       : revenueGraphType === "bar"
       ? getBaseBarDataset
+      : revenueGraphType === "pie"
+      ? (label, data) =>
+          getBasePieDataset(label, data, data.map(() => revenueGraphColor))
       : getBaseLineDataset;
 
   const data = {
@@ -59,7 +63,12 @@ export const RevenueChart = ({ analytics }) => {
   };
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.standard);
-  const ChartComponent = revenueGraphType === "bar" ? Bar : Line;
+  const ChartComponent =
+    revenueGraphType === "bar"
+      ? Bar
+      : revenueGraphType === "pie"
+      ? Pie
+      : Line;
 
   return (
     <div style={{ width: "100%", maxWidth: "700px", margin: "auto" }}>

--- a/frontend/src/modules/analytics/components/SalesCard.jsx
+++ b/frontend/src/modules/analytics/components/SalesCard.jsx
@@ -16,7 +16,7 @@ import {
   MenuItem,
   Button,
 } from "@mui/material";
-import { EllipsisVertical, ArrowRight, BarChart2, Type } from "lucide-react";
+import { EllipsisVertical, ArrowRight, BarChart2, Type, List } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 export const SalesCard = ({
@@ -29,6 +29,7 @@ export const SalesCard = ({
   const { setShowTotalSalesCard } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
   const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [showChart, setShowChart] = useState(true);
   const {
     setsalesGraphColor,
     setSalesGraphType,
@@ -138,6 +139,16 @@ export const SalesCard = ({
                   </MenuItem>
                   <MenuItem
                     onClick={() => {
+                      setShowChart(!showChart);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <List style={{ marginRight: 8 }} />
+                    {showChart ? "Numeric only" : "Show chart"}
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
                       setSalesValueFormat(
                         salesValueFormat === "currency" ? "number" : "currency"
                       );
@@ -157,7 +168,7 @@ export const SalesCard = ({
                 : analytics?.total_sales_count}
             </Typography>
 
-            <SalesChart analytics={analytics} />
+            {showChart && <SalesChart analytics={analytics} />}
 
             <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
               <Button

--- a/frontend/src/modules/analytics/components/SalesChart.jsx
+++ b/frontend/src/modules/analytics/components/SalesChart.jsx
@@ -1,4 +1,4 @@
-import { Line, Bar } from "react-chartjs-2";
+import { Line, Bar, Pie } from "react-chartjs-2";
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -18,6 +18,7 @@ import {
   getBaseLineDataset,
   getSharpLineDataset,
   getBaseBarDataset,
+  getBasePieDataset,
   formatChartLabels,
   getChartTitle,
 } from "../../common/config/chartConfig";
@@ -51,6 +52,9 @@ export const SalesChart = ({ analytics }) => {
       ? getSharpLineDataset
       : salesGraphType === "bar"
       ? getBaseBarDataset
+      : salesGraphType === "pie"
+      ? (label, data) =>
+          getBasePieDataset(label, data, data.map(() => salesGraphColor))
       : getBaseLineDataset;
 
   const data = {
@@ -59,7 +63,12 @@ export const SalesChart = ({ analytics }) => {
   };
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.standard);
-  const ChartComponent = salesGraphType === "bar" ? Bar : Line;
+  const ChartComponent =
+    salesGraphType === "bar"
+      ? Bar
+      : salesGraphType === "pie"
+      ? Pie
+      : Line;
 
   return (
     <div style={{ width: "100%", maxWidth: "700px", margin: "auto" }}>

--- a/frontend/src/modules/analytics/components/SalesOverTime.jsx
+++ b/frontend/src/modules/analytics/components/SalesOverTime.jsx
@@ -1,4 +1,4 @@
-import { Line } from "react-chartjs-2";
+import { Line, Bar } from "react-chartjs-2";
 import { useState } from "react";
 import { EyeSlash, Palette } from "react-bootstrap-icons";
 import { useSettings } from "../../common/contexts/SettingsContext";
@@ -13,10 +13,13 @@ import {
   Card,
   CardContent,
 } from "@mui/material";
-import { EllipsisVertical } from "lucide-react";
+import { EllipsisVertical, BarChart2 } from "lucide-react";
+import GraphTypeSelector from "./GraphTypeSelector";
 import {
   getBaseLineChartOptions,
   getBaseLineDataset,
+  getSharpLineDataset,
+  getBaseBarDataset,
   formatChartLabels,
   getChartTitle,
   CHART_CONFIGS,
@@ -26,6 +29,8 @@ const SalesOverTime = ({ analytics }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const { setShowSalesOverTime } = useSettings();
   const [showGraphColorPalette, setShowGraphColorPalette] = useState(false);
+  const [showGraphTypeSelector, setShowGraphTypeSelector] = useState(false);
+  const [graphType, setGraphType] = useState("line");
   const { setSalesOverTimeGraphColor, salesOverTimeGraphColor } = useSettings();
 
   const handleMenuOpen = (event) => {
@@ -49,15 +54,20 @@ const SalesOverTime = ({ analytics }) => {
   const labels = formatChartLabels(salesData, granularity);
   const dataValues = salesData.map((item) => item.sales);
   const chartTitle = getChartTitle("sales", granularity);
+  const datasetFn =
+    graphType === "sharp"
+      ? getSharpLineDataset
+      : graphType === "bar"
+      ? getBaseBarDataset
+      : getBaseLineDataset;
 
   const data = {
     labels,
-    datasets: [
-      getBaseLineDataset(chartTitle, dataValues, salesOverTimeGraphColor),
-    ],
+    datasets: [datasetFn(chartTitle, dataValues, salesOverTimeGraphColor)],
   };
 
   const options = getBaseLineChartOptions(CHART_CONFIGS.standard);
+  const ChartComponent = graphType === "bar" ? Bar : Line;
 
   return (
     <>
@@ -111,16 +121,26 @@ const SalesOverTime = ({ analytics }) => {
                       <EyeSlash style={{ marginRight: 8 }} />
                       Hide
                     </MenuItem>
-                    <MenuItem
-                      onClick={() => {
-                        setShowGraphColorPalette(true);
-                        handleMenuClose();
-                      }}
-                      sx={{ py: 1 }}
-                    >
-                      <Palette style={{ marginRight: 8 }} />
-                      Customize color
-                    </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      setShowGraphColorPalette(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <Palette style={{ marginRight: 8 }} />
+                    Customize color
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      setShowGraphTypeSelector(true);
+                      handleMenuClose();
+                    }}
+                    sx={{ py: 1 }}
+                  >
+                    <BarChart2 style={{ marginRight: 8 }} />
+                    Graph type
+                  </MenuItem>
                   </Menu>
                 </Box>
               </Box>
@@ -139,7 +159,7 @@ const SalesOverTime = ({ analytics }) => {
                 </Typography>
               </Box>
               
-              <Line data={data} options={options} />
+              <ChartComponent data={data} options={options} />
             </Box>
           </CardContent>
         </Card>
@@ -148,6 +168,14 @@ const SalesOverTime = ({ analytics }) => {
         showGraphColorPalette={showGraphColorPalette}
         setShowGraphColorPalette={setShowGraphColorPalette}
         onSelectColor={onSelectColor}
+      />
+      <GraphTypeSelector
+        open={showGraphTypeSelector}
+        onClose={() => setShowGraphTypeSelector(false)}
+        onSelectType={(type) => {
+          setGraphType(type);
+          setShowGraphTypeSelector(false);
+        }}
       />
     </>
   );

--- a/frontend/src/modules/common/config/chartConfig.js
+++ b/frontend/src/modules/common/config/chartConfig.js
@@ -5,6 +5,7 @@ import {
   PointElement,
   LineElement,
   BarElement,
+  ArcElement,
   Title,
   Tooltip,
   Legend,
@@ -18,6 +19,7 @@ ChartJS.register(
   PointElement,
   LineElement,
   BarElement,
+  ArcElement,
   Title,
   Tooltip,
   Legend,
@@ -84,6 +86,17 @@ export const getBaseBarDataset = (label, data, color, customConfig = {}) => {
     data,
     backgroundColor: color,
     borderColor: color,
+    borderWidth: 1,
+    ...customConfig,
+  };
+};
+
+export const getBasePieDataset = (label, data, color, customConfig = {}) => {
+  return {
+    label,
+    data,
+    backgroundColor: Array.isArray(color) ? color : [color],
+    borderColor: Array.isArray(color) ? color : [color],
     borderWidth: 1,
     ...customConfig,
   };


### PR DESCRIPTION
## Summary
- allow customizing graph colors with a hex input and picker
- add pie to graph type selector
- support pie view for analytics charts
- add option to hide charts and show numbers only
- enable graph type selection on time-series cards

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688311d7765c832286eba81d67732650