### PR TITLE
[docs] Add index and analysis

### DIFF
--- a/CODEBASE_ANALYSIS.md
+++ b/CODEBASE_ANALYSIS.md
@@ -1,0 +1,43 @@
+# Codebase Analysis
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
+
+This document provides an overview of how RoyaltyX is structured at a high level. It is intended for contributors who want to understand where the main features live before diving into the code.
+
+## Backend
+
+The backend is a Django project located in the `backend/` folder. Each major feature is encapsulated in a Django app under `backend/apps/`.
+
+- **authentication** – Provides JWT auth, password management and OAuth callbacks.
+- **user** – Custom user model and subscription plan tracking.
+- **payments** – Stripe integration, subscription management and webhook processing.
+- **analytics** – Aggregates product sales and impressions, storing summary records for quick dashboards.
+- **sources** – Handles synchronization with third‑party platforms like YouTube, TikTok and Vimeo.
+- **data_imports** – Parses CSV/XLSX files for manual revenue uploads.
+- **emails** – Celery tasks and templates for transactional emails.
+- **report** – PDF report generation and template management.
+- **support** – In‑app help desk tickets.
+
+Celery workers and beat tasks are configured in `backend/royaltyx/` and run side by side with the Django application. Tests live next to the code in each app.
+
+## Frontend
+
+The React application resides in `frontend/`. Source files are grouped by feature within `src/modules/`:
+
+- **account** – Billing history, payment methods and membership pages.
+- **analytics** – Dashboard components and charts.
+- **management** – Admin style pages for producers, fees and settings.
+- **projects** – Create and manage projects and products.
+- **reports** – PDF template builder and report list pages.
+- **sources** – Connect external platforms and upload data manually.
+- **support** – Customer support page and help resources.
+
+Shared components live under `src/modules/common`. The project uses React Router for navigation and Material‑UI for styling. Tests use React Testing Library.
+
+## Infrastructure
+
+Docker compose files (`local.yml` and `production.yml`) orchestrate PostgreSQL, Redis, Celery workers, Nginx, and both the frontend and backend services. GitHub Actions run the test suites and linting on every push.
+
+For a more general description of folders see [CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). The [Documentation Overview](documentation/DOCUMENTATION_OVERVIEW.md) lists every guide available under the `documentation/` directory.
+
+

--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -1,4 +1,6 @@
 # Codebase Overview
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 This document summarizes the overall architecture of the RoyaltyX project. It is intended as a starting point for new contributors who want a high level understanding of how the system is organized.
 
@@ -55,5 +57,6 @@ Backend tests run with Django's test runner. Frontend tests run via `react-scrip
 
 Additional guides live in the `documentation/` directory and as Markdown files
 in the repository root. See [README.md](README.md) for setup instructions,
-payment integration details and more. A detailed listing of Django apps is
+payment integration details and more. [Documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) lists every guide at a glance. A detailed listing of Django apps is
 available in [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
+

--- a/PAID_PLANS.md
+++ b/PAID_PLANS.md
@@ -1,4 +1,6 @@
 # Paid Plans
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 ### Discovery
 

--- a/PAYMENT_INTEGRATION_SUMMARY.md
+++ b/PAYMENT_INTEGRATION_SUMMARY.md
@@ -1,4 +1,6 @@
 # Complete Stripe Payment Integration Summary
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 ## 🎉 Implementation Complete
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # RoyaltyX - Content & Royalty Management Platform
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 ## 🎯 What is RoyaltyX?
 
 RoyaltyX is a comprehensive content and royalty management platform designed to empower content creators, artists, and digital entrepreneurs. Our platform helps you track, manage, and optimize your revenue streams across multiple channels while providing powerful analytics and insights to grow your business.
+
+All available documentation is listed in [Documentation Overview](documentation/DOCUMENTATION_OVERVIEW.md).
 
 ### 🚀 Why RoyaltyX?
 
@@ -377,7 +381,9 @@ docker-compose -f local.yml up -d postgres
 ## 📁 Project Structure
 
 For a high level walkthrough of the repository layout see
-[CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). For details on individual Django
+[CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). Detailed analysis of where the
+major features live is available in
+[CODEBASE_ANALYSIS.md](CODEBASE_ANALYSIS.md). For details on individual Django
 apps check [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
 
 ```
@@ -468,7 +474,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📞 Support
 
-- **Documentation**: Check our comprehensive docs
+- **Documentation**: See [Documentation Overview](documentation/DOCUMENTATION_OVERVIEW.md) for a list of all guides
 - **AI Help Chat**: Use the built-in chat at `/admin/documentation/chat` for quick tips
 - **Issues**: Report bugs on GitHub Issues
 - **Email**: support@royaltyx.com

--- a/STRIPE_PAYMENT_INTEGRATION.md
+++ b/STRIPE_PAYMENT_INTEGRATION.md
@@ -1,4 +1,6 @@
 # Stripe Payment Integration Documentation
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 This document describes the complete Stripe payment integration for the RoyaltyX subscription system.
 

--- a/STRIPE_SETUP_COMPLETE_GUIDE.md
+++ b/STRIPE_SETUP_COMPLETE_GUIDE.md
@@ -1,4 +1,6 @@
 # Complete Stripe Integration Setup Guide
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 ## Current Issue
 - Payments succeed in Stripe ✅

--- a/WEBHOOK_SETUP_INSTRUCTIONS.md
+++ b/WEBHOOK_SETUP_INSTRUCTIONS.md
@@ -1,4 +1,6 @@
 # Webhook Setup Instructions for RoyaltyX Stripe Integration
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 ## Problem
 Stripe webhooks are not reaching your local development server, so successful payments don't automatically update subscription plans.

--- a/WHITE_LABEL_BRANDING.md
+++ b/WHITE_LABEL_BRANDING.md
@@ -1,4 +1,6 @@
 # White-Label Branding Setup
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
 
 This guide explains how to brand RoyaltyX as your own platform and resell it to clients.
 

--- a/documentation/ANALYTICS_OVERVIEW.md
+++ b/documentation/ANALYTICS_OVERVIEW.md
@@ -1,4 +1,6 @@
 # Analytics Data Overview
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 RoyaltyX stores raw sales and impression data and calculates aggregated metrics when needed.
 

--- a/documentation/API_OVERVIEW.md
+++ b/documentation/API_OVERVIEW.md
@@ -1,4 +1,6 @@
 # API Overview
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This document lists the primary REST endpoints exposed by RoyaltyX. The complete OpenAPI specification is stored in [../backend/schema.yml](../backend/schema.yml) and is served live at `/docs/` when the application is running.
 

--- a/documentation/ARCHITECTURE_OVERVIEW.md
+++ b/documentation/ARCHITECTURE_OVERVIEW.md
@@ -1,4 +1,6 @@
 # Architecture Overview
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This diagram shows how the main services communicate when running RoyaltyX with Docker.
 

--- a/documentation/BACKEND_APPS.md
+++ b/documentation/BACKEND_APPS.md
@@ -1,4 +1,6 @@
 # Backend App Reference
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This document lists the Django apps included in the `backend/apps` directory and briefly describes what each one does.
 

--- a/documentation/DEVELOPER_GUIDE.md
+++ b/documentation/DEVELOPER_GUIDE.md
@@ -1,4 +1,6 @@
 # Developer Guide
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This guide complements the existing [AGENTS.md](../AGENTS.md) instructions.
 It highlights common tasks and the tooling used in this repository.

--- a/documentation/DOCUMENTATION_OVERVIEW.md
+++ b/documentation/DOCUMENTATION_OVERVIEW.md
@@ -1,0 +1,17 @@
+# Documentation Overview
+
+This page lists all of the available guides in the `documentation/` directory with short descriptions. Use it as a quick reference when exploring the project.
+
+| File | Description |
+| ---- | ----------- |
+| **ARCHITECTURE_OVERVIEW.md** | High level diagram of how the services communicate when running with Docker. |
+| **ANALYTICS_OVERVIEW.md** | Explains how raw analytics data is stored and how aggregated metrics are generated. |
+| **API_OVERVIEW.md** | Summary of the main REST endpoints exposed by the backend. |
+| **BACKEND_APPS.md** | Table of Django apps in `backend/apps` with a description of what each one does. |
+| **FEE_SYSTEM.md** | Details the configurable fee rules applied to revenue events. |
+| **INITIAL_SETUP_TUTORIAL.md** | Step‑by‑step walkthrough for getting a local environment running. |
+| **MANUAL_DATA_UPLOAD.md** | Guide to importing sales and impression data from CSV or Excel files. |
+| **NON_DOCKER_SETUP.md** | Instructions for running the services directly on your machine without Docker. |
+| **PDF_TEMPLATE_CUSTOMIZER.md** | Documentation for the PDF report template customizer and its options. |
+
+

--- a/documentation/FEE_SYSTEM.md
+++ b/documentation/FEE_SYSTEM.md
@@ -1,4 +1,6 @@
 # Fee System Overview
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 RoyaltyX supports a flexible fee system for charging producers and products. Fees are defined per project and can be grouped together for easier management.
 

--- a/documentation/INITIAL_SETUP_TUTORIAL.md
+++ b/documentation/INITIAL_SETUP_TUTORIAL.md
@@ -1,4 +1,6 @@
 # Initial Setup Tutorial
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This guide walks you through setting up RoyaltyX for local development. A short video walkthrough is available at [YouTube](https://youtu.be/dQw4w9WgXcQ).
 

--- a/documentation/MANUAL_DATA_UPLOAD.md
+++ b/documentation/MANUAL_DATA_UPLOAD.md
@@ -1,4 +1,6 @@
 # Manual Data Upload Workflow
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This guide explains how to import sales and impression data into RoyaltyX using the manual uploader. Use this process when you receive monthly reports from platforms that aren't integrated through an API.
 

--- a/documentation/NON_DOCKER_SETUP.md
+++ b/documentation/NON_DOCKER_SETUP.md
@@ -1,4 +1,6 @@
 # Running RoyaltyX Without Docker
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 This guide explains how to run the backend and frontend directly on your machine without Docker.
 See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for tips on linting and running tests.

--- a/documentation/PDF_TEMPLATE_CUSTOMIZER.md
+++ b/documentation/PDF_TEMPLATE_CUSTOMIZER.md
@@ -1,4 +1,6 @@
 # PDF Template Customizer Overview
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
 
 The PDF template customizer in RoyaltyX gives you full control over the look and feel of generated reports. Below is a summary of the available features.
 


### PR DESCRIPTION
## Summary
- add CODEBASE_ANALYSIS doc
- add documentation index listing all guides
- link docs to the new index

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68831b1f069883229a8f2b6488678bc6