### PR TITLE
[docs] update docs with detailed analysis

### DIFF
--- a/CODEBASE_DETAILED_ANALYSIS.md
+++ b/CODEBASE_DETAILED_ANALYSIS.md
@@ -1,0 +1,62 @@
+# Detailed Codebase Analysis
+See [documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
+
+
+This guide expands on [CODEBASE_ANALYSIS.md](CODEBASE_ANALYSIS.md) with a more in‑depth look at each part of the repository. Use it when you need to understand how the pieces fit together before adding new features.
+
+## Backend Structure
+
+The Django project lives in `backend/` and is organised into reusable apps inside `backend/apps/`.
+
+### apps/authentication
+Handles user registration, login via JWT and optional OAuth callbacks. Provides password reset endpoints and basic profile views.
+
+### apps/user
+Extends the default Django user model with subscription information. Manages subscription plan choices and exposes endpoints to fetch or update the plan.
+
+### apps/payments
+Wraps Stripe billing. Implements checkout session creation, subscription updates, webhook handling and invoice retrieval. Celery tasks send emails on failed payments or cancellations.
+
+### apps/analytics
+Calculates revenue and impression metrics from `ProductSale` and `ProductImpressions` models. Aggregates data per project and exposes API endpoints for dashboards.
+
+### apps/sources
+Synchronises external platforms such as YouTube and TikTok. Also supports manual CSV/XLSX data uploads through the `data_imports` app.
+
+### apps/report
+Generates PDF reports using configurable templates. Works with the `emails` app to deliver reports via email if required.
+
+### Other apps
+`admin_panel`, `support`, `fees`, `notifications`, `inbox`, `project` and `product` provide admin tools, help desk features, fee calculation and product management. Each app keeps its own serializers, views and tests close to the models they operate on.
+
+### royaltyx/
+Contains project settings, Celery configuration and the Django entrypoint. Beat tasks schedule synchronisation jobs and payment checks.
+
+## Frontend Structure
+
+The React code is stored in `frontend/`. Pages are grouped by feature under `src/modules/`.
+
+- **account** – membership page, billing history and payment method management.
+- **analytics** – dashboard charts and tables showing project performance.
+- **management** – admin style screens for producers, fees and settings.
+- **projects** – create and manage projects and products.
+- **reports** – PDF template customiser and report listings.
+- **sources** – connect third‑party platforms and upload manual data files.
+- **support** – help centre and contact forms.
+
+Shared UI components live under `src/modules/common`. Routing is handled by React Router and Material‑UI provides styling components.
+
+## Infrastructure
+
+Docker compose files (`local.yml` and `production.yml`) start PostgreSQL, Redis, Celery workers, the Django backend and the React frontend. Nginx serves both applications in production. GitHub Actions under `.github/workflows/` run tests and linting for every push.
+
+## Testing
+
+Backend tests use Django's test runner and can be invoked with `python manage.py test` inside `backend/`. Frontend tests run with `npm test` inside `frontend/`. The `conftest.py` file configures Django for running tests outside of Docker.
+
+## Where to Go Next
+
+- [CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md) – quick look at the folder structure.
+- [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md) – table listing every Django app.
+- [documentation/DEVELOPER_GUIDE.md](documentation/DEVELOPER_GUIDE.md) – tips for linting and test commands.
+

--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -58,5 +58,6 @@ Backend tests run with Django's test runner. Frontend tests run via `react-scrip
 Additional guides live in the `documentation/` directory and as Markdown files
 in the repository root. See [README.md](README.md) for setup instructions,
 payment integration details and more. [Documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) lists every guide at a glance. A detailed listing of Django apps is
-available in [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
+available in [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md). For a component-by-component walk-through see
+[CODEBASE_DETAILED_ANALYSIS.md](CODEBASE_DETAILED_ANALYSIS.md).
 

--- a/README.md
+++ b/README.md
@@ -381,10 +381,12 @@ docker-compose -f local.yml up -d postgres
 ## 📁 Project Structure
 
 For a high level walkthrough of the repository layout see
-[CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). Detailed analysis of where the
+[CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). A summary of where the
 major features live is available in
-[CODEBASE_ANALYSIS.md](CODEBASE_ANALYSIS.md). For details on individual Django
-apps check [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
+[CODEBASE_ANALYSIS.md](CODEBASE_ANALYSIS.md). For an even deeper dive into each
+component read [CODEBASE_DETAILED_ANALYSIS.md](CODEBASE_DETAILED_ANALYSIS.md).
+For details on individual Django apps check
+[documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
 
 ```
 RoyaltyX/

--- a/documentation/DOCUMENTATION_OVERVIEW.md
+++ b/documentation/DOCUMENTATION_OVERVIEW.md
@@ -14,4 +14,18 @@ This page lists all of the available guides in the `documentation/` directory wi
 | **NON_DOCKER_SETUP.md** | Instructions for running the services directly on your machine without Docker. |
 | **PDF_TEMPLATE_CUSTOMIZER.md** | Documentation for the PDF report template customizer and its options. |
 
+## Additional Root Documentation
+
+The repository root contains several other guides:
+
+- [CODEBASE_OVERVIEW.md](../CODEBASE_OVERVIEW.md) – folder layout and general architecture.
+- [CODEBASE_ANALYSIS.md](../CODEBASE_ANALYSIS.md) – summary of key features and where they live.
+- [CODEBASE_DETAILED_ANALYSIS.md](../CODEBASE_DETAILED_ANALYSIS.md) – in‑depth breakdown of every major component.
+- [PAID_PLANS.md](../PAID_PLANS.md) – overview of subscription tiers and add‑ons.
+- [PAYMENT_INTEGRATION_SUMMARY.md](../PAYMENT_INTEGRATION_SUMMARY.md) – recap of the Stripe integration work.
+- [STRIPE_PAYMENT_INTEGRATION.md](../STRIPE_PAYMENT_INTEGRATION.md) – complete payment flow documentation.
+- [STRIPE_SETUP_COMPLETE_GUIDE.md](../STRIPE_SETUP_COMPLETE_GUIDE.md) – tips for configuring Stripe webhooks.
+- [WEBHOOK_SETUP_INSTRUCTIONS.md](../WEBHOOK_SETUP_INSTRUCTIONS.md) – how to forward Stripe webhooks during development.
+- [WHITE_LABEL_BRANDING.md](../WHITE_LABEL_BRANDING.md) – steps for rebranding the platform.
+- [backend/SUBSCRIPTION_PLANS.md](../backend/SUBSCRIPTION_PLANS.md) – API details for subscription plan endpoints.
 


### PR DESCRIPTION
## Summary
- add CODEBASE_DETAILED_ANALYSIS with deeper project breakdown
- expand README and CODEBASE_OVERVIEW with links to the new guide
- list root-level docs in DOCUMENTATION_OVERVIEW

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68831f24e144832280ac142d405383ac