### PR TITLE
[docs] add deep code analysis and update docs

### DIFF
--- a/CODEBASE_ANALYSIS.md
+++ b/CODEBASE_ANALYSIS.md
@@ -40,4 +40,7 @@ Docker compose files (`local.yml` and `production.yml`) orchestrate PostgreSQL, 
 
 For a more general description of folders see [CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). The [Documentation Overview](documentation/DOCUMENTATION_OVERVIEW.md) lists every guide available under the `documentation/` directory.
 
+For an expanded walkthrough of every backend app and frontend module see
+[documentation/DEEP_CODE_ANALYSIS.md](documentation/DEEP_CODE_ANALYSIS.md).
+
 

--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -59,4 +59,6 @@ Additional guides live in the `documentation/` directory and as Markdown files
 in the repository root. See [README.md](README.md) for setup instructions,
 payment integration details and more. [Documentation/DOCUMENTATION_OVERVIEW.md](documentation/DOCUMENTATION_OVERVIEW.md) lists every guide at a glance. A detailed listing of Django apps is
 available in [documentation/BACKEND_APPS.md](documentation/BACKEND_APPS.md).
+For a more thorough walkthrough of each backend app and frontend module see
+[documentation/DEEP_CODE_ANALYSIS.md](documentation/DEEP_CODE_ANALYSIS.md).
 

--- a/documentation/DEEP_CODE_ANALYSIS.md
+++ b/documentation/DEEP_CODE_ANALYSIS.md
@@ -1,0 +1,73 @@
+# Deep Codebase Analysis
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
+This document provides a deeper summary of how the RoyaltyX project is organised. It
+combines information about the Django backend apps and the React frontend modules.
+
+## Backend Apps
+
+The `backend/apps/` folder contains isolated Django apps. Each app focuses on a
+specific domain. Below is a short description of every folder:
+
+| App | Purpose |
+| --- | ------- |
+| **admin_panel** | Views used by the internal Django admin panel. |
+| **analytics** | Aggregates sales and impression data for dashboard metrics. |
+| **authentication** | JWT auth endpoints and third‑party OAuth callbacks. |
+| **data_imports** | CSV/XLSX importers for manual revenue uploads. |
+| **emails** | Email templates and Celery tasks for transactional emails. |
+| **fees** | Configurable fee rules applied to revenue events. |
+| **inbox** | Basic in‑app messaging and notifications. |
+| **notifications** | Manages user notifications and settings. |
+| **oauth** | OAuth flows for Google, TikTok, Twitch and Vimeo. |
+| **payments** | Stripe integration, webhook handling and plan logic. |
+| **product** | Models for products, files and media. |
+| **project** | Multi‑project support and permissions. |
+| **report** | PDF report generation and template management. |
+| **sources** | Synchronises data from external platforms like YouTube. |
+| **support** | Simple help desk and FAQ system. |
+| **user** | Custom user model and profile management. |
+
+Celery workers and beat tasks are configured in `backend/royaltyx/` and run
+alongside the Django application.
+
+## Frontend Modules
+
+The React application under `frontend/` mirrors the backend structure. Feature
+modules live in `src/modules/`:
+
+| Module | Description |
+| ------ | ----------- |
+| **account** | Billing history and membership pages. |
+| **admin_panel** | Admin‑only dashboard views. |
+| **analytics** | Charts and widgets for revenue metrics. |
+| **authentication** | Login, registration and OAuth screens. |
+| **common** | Reusable components shared across the app. |
+| **content** | Media management pages and upload forms. |
+| **dashboard** | Landing dashboard after login. |
+| **global** | Global state (context providers, themes). |
+| **management** | Admin style pages for producers and settings. |
+| **members** | Team member management UI. |
+| **oauth** | Handles frontend pieces of OAuth flows. |
+| **products** | Product listing and detail pages. |
+| **projects** | Manage projects and assign users. |
+| **reports** | PDF template builder and reports list. |
+| **sources** | Connect external platforms and manual uploads. |
+| **support** | Customer support and help resources. |
+| **white_label** | White‑label branding options. |
+
+The modules communicate with the backend via Axios-based API helpers located in
+each module’s `api/` directory.
+
+## Tests
+
+- **Backend tests** live next to the Django apps and run with `pytest`.
+- **Frontend tests** use React Testing Library and run with `npm test`.
+
+Both suites execute in continuous integration via GitHub Actions.
+
+## Further Reading
+
+- [CODEBASE_OVERVIEW.md](../CODEBASE_OVERVIEW.md) – High level repository layout.
+- [CODEBASE_ANALYSIS.md](../CODEBASE_ANALYSIS.md) – Shorter summary of major features.
+

--- a/documentation/DOCUMENTATION_OVERVIEW.md
+++ b/documentation/DOCUMENTATION_OVERVIEW.md
@@ -13,5 +13,11 @@ This page lists all of the available guides in the `documentation/` directory wi
 | **MANUAL_DATA_UPLOAD.md** | Guide to importing sales and impression data from CSV or Excel files. |
 | **NON_DOCKER_SETUP.md** | Instructions for running the services directly on your machine without Docker. |
 | **PDF_TEMPLATE_CUSTOMIZER.md** | Documentation for the PDF report template customizer and its options. |
+| **DEEP_CODE_ANALYSIS.md** | In‑depth look at each backend app and frontend module. |
 
+Additional high level documents live in the repository root:
+
+- [README.md](../README.md) – Project introduction and setup instructions.
+- [CODEBASE_OVERVIEW.md](../CODEBASE_OVERVIEW.md) – High level folder structure.
+- [CODEBASE_ANALYSIS.md](../CODEBASE_ANALYSIS.md) – Short summary of major features.
 


### PR DESCRIPTION
## Summary
- add DEEP_CODE_ANALYSIS doc summarizing backend apps and frontend modules
- update documentation overview with new file and links to root guides
- cross reference the new doc in CODEBASE_ANALYSIS and CODEBASE_OVERVIEW

## Testing
- `pytest -q`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68831fa08e588322af9aa13f438a55ed