### PR TITLE
[docs] expand codebase analysis and add root guide index

### DIFF
--- a/CODEBASE_ANALYSIS.md
+++ b/CODEBASE_ANALYSIS.md
@@ -6,17 +6,28 @@ This document provides an overview of how RoyaltyX is structured at a high level
 
 ## Backend
 
-The backend is a Django project located in the `backend/` folder. Each major feature is encapsulated in a Django app under `backend/apps/`.
+The backend is a Django project located in the `backend/` folder. Each major feature is implemented as a Django app under `backend/apps/`.
 
+The full list of apps is:
+
+- **admin_panel** – Custom views for the Django admin dashboard.
+- **analytics** – Aggregates sales and impression data for charts and tables.
 - **authentication** – Provides JWT auth, password management and OAuth callbacks.
-- **user** – Custom user model and subscription plan tracking.
-- **payments** – Stripe integration, subscription management and webhook processing.
-- **analytics** – Aggregates product sales and impressions, storing summary records for quick dashboards.
-- **sources** – Handles synchronization with third‑party platforms like YouTube, TikTok and Vimeo.
 - **data_imports** – Parses CSV/XLSX files for manual revenue uploads.
 - **emails** – Celery tasks and templates for transactional emails.
+- **fees** – Defines configurable project fees and calculates adjustments.
+- **inbox** – Notification inbox for system alerts.
+- **notifications** – Banner and email notifications for events.
+- **oauth** – OAuth client logic for third‑party integrations.
+- **payments** – Stripe integration, subscription management and webhook processing.
+- **product** – Product catalogue models and API endpoints.
+- **project** – Core project management models and permissions.
 - **report** – PDF report generation and template management.
-- **support** – In‑app help desk tickets.
+- **sources** – Syncs data from external platforms like YouTube and TikTok.
+- **support** – Help desk tickets and FAQ articles.
+- **user** – Custom user model and subscription plan tracking.
+
+Shared utilities live in `backend/common`, providing helpers such as encryption tools, base API views and reusable management commands. Project configuration and Celery setup reside in `backend/royaltyx/`.
 
 Celery workers and beat tasks are configured in `backend/royaltyx/` and run side by side with the Django application. Tests live next to the code in each app.
 
@@ -36,7 +47,7 @@ Shared components live under `src/modules/common`. The project uses React Router
 
 ## Infrastructure
 
-Docker compose files (`local.yml` and `production.yml`) orchestrate PostgreSQL, Redis, Celery workers, Nginx, and both the frontend and backend services. GitHub Actions run the test suites and linting on every push.
+Docker compose files (`local.yml` and `production.yml`) orchestrate PostgreSQL, Redis, Celery workers, Nginx, and the frontend and backend containers. The `nginx/` directory contains the production configuration used by the `production.yml` stack. Environment variables are loaded from `.env` files and an optional `scripts/update-domain.sh` helper adjusts domain names during deployment. GitHub Actions run backend and frontend tests along with linting on every push.
 
 For a more general description of folders see [CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md). The [Documentation Overview](documentation/DOCUMENTATION_OVERVIEW.md) lists every guide available under the `documentation/` directory.
 

--- a/backend/SUBSCRIPTION_PLANS.md
+++ b/backend/SUBSCRIPTION_PLANS.md
@@ -1,4 +1,5 @@
 # Subscription Plans API Documentation
+See [Documentation Overview](../documentation/DOCUMENTATION_OVERVIEW.md) for a full index of guides.
 
 This document describes the subscription plan functionality that has been integrated into the RoyaltyX backend.
 

--- a/documentation/DOCUMENTATION_OVERVIEW.md
+++ b/documentation/DOCUMENTATION_OVERVIEW.md
@@ -14,4 +14,21 @@ This page lists all of the available guides in the `documentation/` directory wi
 | **NON_DOCKER_SETUP.md** | Instructions for running the services directly on your machine without Docker. |
 | **PDF_TEMPLATE_CUSTOMIZER.md** | Documentation for the PDF report template customizer and its options. |
 
+## Root-Level Guides
+
+The repository root also contains additional guides and references.
+
+| File | Description |
+| ---- | ----------- |
+| **AGENTS.md** | Contributor workflow guidelines and testing instructions. |
+| **CODEBASE_ANALYSIS.md** | Detailed walkthrough of backend apps, frontend modules and infrastructure. |
+| **CODEBASE_OVERVIEW.md** | Summarizes the repository layout and architecture. |
+| **PAID_PLANS.md** | Breakdown of subscription tiers and pricing. |
+| **PAYMENT_INTEGRATION_SUMMARY.md** | Summary of how Stripe is integrated for payments. |
+| **README.md** | Project introduction, setup instructions and FAQ. |
+| **STRIPE_PAYMENT_INTEGRATION.md** | Detailed instructions for connecting to Stripe. |
+| **STRIPE_SETUP_COMPLETE_GUIDE.md** | End-to-end steps for a full Stripe setup. |
+| **WEBHOOK_SETUP_INSTRUCTIONS.md** | How to configure Stripe webhooks. |
+| **WHITE_LABEL_BRANDING.md** | Steps for custom branding and reseller mode. |
+
 


### PR DESCRIPTION
## Summary
- cover each Django app and shared utilities in CODEBASE_ANALYSIS
- explain infra stack in CODEBASE_ANALYSIS
- index top-level guides inside DOCUMENTATION_OVERVIEW
- link SUBSCRIPTION_PLANS back to docs overview

## Testing
- `python manage.py test`
- `ruff check .`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6883263836d48322be7153a9d88026c0