### PR TITLE
[scripts] standardize environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ For a visual overview of these components see
    cd RoyaltyX
    ```
 
-2. **Set up environment variables**
+2. **Initialize the local environment**
    ```bash
-   cp .env.example .env
-   # Edit .env with your configuration
+   ./scripts/setup-local.sh
    ```
-   
-   See the [Initial Setup Tutorial](documentation/INITIAL_SETUP_TUTORIAL.md)
-   for a complete walkthrough and video guide.
+
+   This script copies `.env.example` to `.env` if needed and installs backend
+   and frontend dependencies. See the
+   [Initial Setup Tutorial](documentation/INITIAL_SETUP_TUTORIAL.md) for a full
+   walkthrough and video guide.
 
 3. **Start the application**
    ```bash

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Standardize local environment setup for RoyaltyX
+set -e
+
+# Create .env if missing
+if [ ! -f .env ]; then
+  cp .env.example .env
+  echo "Created .env from .env.example"
+fi
+
+# Set up Python virtual environment
+if [ ! -d backend/venv ]; then
+  echo "Creating Python virtual environment..."
+  python3 -m venv backend/venv
+fi
+
+echo "Installing backend dependencies..."
+backend/venv/bin/pip install --upgrade pip >/dev/null
+backend/venv/bin/pip install -r backend/requirements.txt >/dev/null
+
+# Install frontend dependencies
+echo "Installing frontend dependencies..."
+cd frontend
+npm install >/dev/null
+cd ..
+
+echo "Local environment setup complete"


### PR DESCRIPTION
## Summary
- add a helper script to standardize local setup
- reference the script in the Quick Start docs

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6883bb24ea5083228ef02d0ed5f83eb3