### PR TITLE
[backend] add custom Stripe exceptions

### DIFF
--- a/backend/apps/payments/exceptions.py
+++ b/backend/apps/payments/exceptions.py
@@ -1,0 +1,34 @@
+class StripeServiceError(Exception):
+    """Base class for Stripe service errors."""
+
+
+class CustomerCreationError(StripeServiceError):
+    """Raised when creating a customer fails."""
+
+
+class CheckoutSessionCreationError(StripeServiceError):
+    """Raised when creating a checkout session fails."""
+
+
+class SubscriptionCancellationError(StripeServiceError):
+    """Raised when canceling a subscription fails."""
+
+
+class SubscriptionUpdateError(StripeServiceError):
+    """Raised when updating a subscription fails."""
+
+
+class PaymentHandlingError(StripeServiceError):
+    """Raised when handling a successful payment fails."""
+
+
+class UserNotFoundError(StripeServiceError):
+    """Raised when a user cannot be found."""
+
+
+class InvoiceRetrievalError(StripeServiceError):
+    """Raised when listing invoices fails."""
+
+
+class PaymentMethodError(StripeServiceError):
+    """Raised for errors related to payment methods."""


### PR DESCRIPTION
## Summary
- define custom Stripe exception classes
- use the new errors in stripe_service

## Testing
- `ruff check .`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6883ba0f3b888322b48919e822554537