### PR TITLE
[backend] validate product project in analytics

### DIFF
--- a/backend/apps/analytics/tests.py
+++ b/backend/apps/analytics/tests.py
@@ -536,3 +536,32 @@ class AnalyticsUtilsOutputTests(TestCase):
         data = calculate_analytics(project.id, {}, start, end, None, "monthly")
         periods = [entry["period"] for entry in data["time_stats"]]
         self.assertEqual(periods[-1], "2024-03")
+
+
+class ProductProjectMismatchTests(TestCase):
+    def test_product_must_belong_to_project(self):
+        project1 = Project.objects.create(name="P1", description="d")
+        project2 = Project.objects.create(name="P2", description="d")
+
+        product = Product.objects.create(
+            project=project1,
+            title="Prod",
+            description="d",
+            statement_frequency="Monthly",
+            first_statement_end_date=date.today(),
+            payment_threshold=0,
+            payment_window=30,
+            is_active=True,
+        )
+
+        from apps.analytics.utils import calculate_analytics
+
+        with self.assertRaises(ValueError):
+            calculate_analytics(
+                project2.id,
+                {},
+                date.today(),
+                date.today(),
+                product.id,
+                "monthly",
+            )

--- a/backend/apps/analytics/utils.py
+++ b/backend/apps/analytics/utils.py
@@ -603,8 +603,16 @@ def calculate_analytics(
     granularity: str = "monthly",
 ) -> Dict[str, Any]:
     if product_id:
-        impressions_qs = ProductImpressions.objects.filter(product_id=product_id)
-        sales_qs = ProductSale.objects.filter(product_id=product_id)
+        try:
+            product = Product.objects.get(id=product_id)
+        except Product.DoesNotExist:
+            impressions_qs = ProductImpressions.objects.none()
+            sales_qs = ProductSale.objects.none()
+        else:
+            if product.project_id != project_id:
+                raise ValueError("Product does not belong to project")
+            impressions_qs = ProductImpressions.objects.filter(product_id=product_id)
+            sales_qs = ProductSale.objects.filter(product_id=product_id)
     else:
         impressions_qs = ProductImpressions.objects.filter(
             product__project_id=project_id


### PR DESCRIPTION
## Summary
- ensure product belongs to the provided project in `calculate_analytics`
- test mismatch of product and project

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d26b1e8483229ed4ab92c407288d