### PR TITLE
[root] switch to docker compose syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ For a visual overview of these components see
 3. **Start the application**
    ```bash
    # Development environment
-   docker-compose -f local.yml up --build
+   docker compose -f local.yml up --build
 
    # Production environment
-   docker-compose -f production.yml up --build
+   docker compose -f production.yml up --build
    ```
    If you want to run the services directly on your machine without Docker,
    follow the steps in
@@ -118,17 +118,17 @@ For a visual overview of these components see
 
 1. **Create a superuser**
    ```bash
-   docker-compose -f local.yml exec backend python manage.py createsuperuser
+   docker compose -f local.yml exec backend python manage.py createsuperuser
    ```
 
 2. **Run database migrations**
    ```bash
-   docker-compose -f local.yml exec backend python manage.py migrate
+   docker compose -f local.yml exec backend python manage.py migrate
    ```
 
 3. **Load initial data (optional)**
    ```bash
-   docker-compose -f local.yml exec backend python manage.py loaddata initial_data.json
+   docker compose -f local.yml exec backend python manage.py loaddata initial_data.json
    ```
 
 ### Loading Initial Data
@@ -138,14 +138,14 @@ user and example records. Loading this data is helpful when exploring the
 platform locally. Run the following command from the repository root:
 
 ```bash
-docker-compose -f local.yml exec backend python manage.py loaddata initial_data.json
+docker compose -f local.yml exec backend python manage.py loaddata initial_data.json
 ```
 
 If you prefer, a custom management command `seed_demo_data` provides the same
 functionality and can be extended for larger datasets:
 
 ```bash
-docker-compose -f local.yml exec backend python manage.py seed_demo_data
+docker compose -f local.yml exec backend python manage.py seed_demo_data
 ```
 
 ### Using the Help Tab
@@ -335,10 +335,10 @@ more thorough walkthrough.
 
 ```bash
 # Backend tests
-docker-compose -f local.yml exec backend python manage.py test
+docker compose -f local.yml exec backend python manage.py test
 
 # Frontend tests
-docker-compose -f local.yml exec frontend npm test
+docker compose -f local.yml exec frontend npm test
 
 # To run frontend tests without Docker:
 cd frontend && npm test -- --watchAll=false
@@ -351,7 +351,7 @@ that your `.env` configuration points to it. When using Docker Compose
 the test commands, e.g.:
 
 ```bash
-docker-compose -f local.yml up -d postgres
+docker compose -f local.yml up -d postgres
 ```
 
 ### Local Testing Environment Setup
@@ -426,13 +426,13 @@ RoyaltyX/
 
 2. **Deploy with Docker**
    ```bash
-   docker-compose -f production.yml up -d --build
+   docker compose -f production.yml up -d --build
    ```
 
 3. **Set up SSL certificate**
    ```bash
    # Using Let's Encrypt
-   docker-compose -f production.yml exec nginx certbot --nginx
+   docker compose -f production.yml exec nginx certbot --nginx
    ```
 
 4. **Enable Celery beat tasks**

--- a/STRIPE_SETUP_COMPLETE_GUIDE.md
+++ b/STRIPE_SETUP_COMPLETE_GUIDE.md
@@ -64,7 +64,7 @@ cancel_url: "http://localhost:3000/account/membership?status=cancelled"
 If webhooks fail, process payments manually:
 
 ```bash
-docker-compose -f local.yml exec backend python manage.py shell -c "
+docker compose -f local.yml exec backend python manage.py shell -c "
 import stripe
 from django.contrib.auth import get_user_model
 from apps.payments.stripe_service import StripeService

--- a/WEBHOOK_SETUP_INSTRUCTIONS.md
+++ b/WEBHOOK_SETUP_INSTRUCTIONS.md
@@ -37,7 +37,7 @@ Stripe webhooks are not reaching your local development server, so successful pa
 If webhooks fail, use this command to process payments manually:
 
 ```bash
-docker-compose -f local.yml exec backend python manage.py shell -c "
+docker compose -f local.yml exec backend python manage.py shell -c "
 import stripe
 from django.contrib.auth import get_user_model
 from apps.payments.stripe_service import StripeService

--- a/backend/SUBSCRIPTION_PLANS.md
+++ b/backend/SUBSCRIPTION_PLANS.md
@@ -148,7 +148,7 @@ Comprehensive tests have been implemented in `apps/user/tests.py` covering:
 
 Run tests with:
 ```bash
-docker-compose -f local.yml exec backend python manage.py test apps.user.tests.SubscriptionPlanTests
+docker compose -f local.yml exec backend python manage.py test apps.user.tests.SubscriptionPlanTests
 ```
 
 ## Migration


### PR DESCRIPTION
## Summary
- use `docker compose` syntax consistently across all docs

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6883c47d6f848322a15c317c0d3efa63