### PR TITLE
[docs] Add help chat guide

### DIFF
--- a/documentation/DOCUMENTATION_OVERVIEW.md
+++ b/documentation/DOCUMENTATION_OVERVIEW.md
@@ -9,6 +9,7 @@ This page lists all of the available guides in the `documentation/` directory wi
 | **API_OVERVIEW.md** | Summary of the main REST endpoints exposed by the backend. |
 | **BACKEND_APPS.md** | Table of Django apps in `backend/apps` with a description of what each one does. |
 | **FEE_SYSTEM.md** | Details the configurable fee rules applied to revenue events. |
+| **HELP_CHAT.md** | How to configure and use the AI-powered help chat feature. |
 | **INITIAL_SETUP_TUTORIAL.md** | Step‑by‑step walkthrough for getting a local environment running. |
 | **MANUAL_DATA_UPLOAD.md** | Guide to importing sales and impression data from CSV or Excel files. |
 | **MULTI_PRODUCT_ANALYTICS.md** | How to compare analytics across multiple products in one dashboard. |

--- a/documentation/HELP_CHAT.md
+++ b/documentation/HELP_CHAT.md
@@ -1,0 +1,7 @@
+# Help Chat
+See [Documentation Overview](DOCUMENTATION_OVERVIEW.md) for a list of all guides.
+
+RoyaltyX provides a small support chat backed by OpenAI. Set the `OPENAI_API_KEY` environment variable in `.env` to enable it.
+
+Send authenticated POST requests to `/support/help/chat/` with a JSON body containing `question`. The API returns the assistant reply and a `thread_id` for follow‑up messages.
+


### PR DESCRIPTION
## Summary
- document the AI-powered help chat
- list it in the documentation overview

## Testing
- `python manage.py test`
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883ddd0b9f883229e921d22dcaa36f3