### PR TITLE
[backend] add CRUD and permission tests

### DIFF
--- a/backend/apps/admin_panel/tests/test_views.py
+++ b/backend/apps/admin_panel/tests/test_views.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.project.models import Project
+from apps.sources.models import Source
+
+
+class AdminPanelPermissionTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.User = get_user_model()
+        self.admin = self.User.objects.create_user(
+            email="admin@example.com", name="Admin", password="pass1234"
+        )
+        self.admin.role = "admin"
+        self.admin.save()
+        self.user = self.User.objects.create_user(
+            email="user@example.com", name="User", password="pass1234"
+        )
+        self.project = Project.objects.create(name="P1")
+        Source.objects.create(
+            account_name="Acc",
+            platform=Source.PLATFORM_YOUTUBE,
+            project=self.project,
+        )
+
+    def test_admin_access_allowed(self):
+        self.client.force_authenticate(user=self.admin)
+        urls = [
+            reverse("admin_dashboard_stats"),
+            reverse("users_list"),
+            reverse("users_stats"),
+            reverse("projects_stats"),
+            reverse("sources_stats"),
+        ]
+        for url in urls:
+            res = self.client.get(url)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_non_admin_denied(self):
+        self.client.force_authenticate(user=self.user)
+        url = reverse("admin_dashboard_stats")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/apps/product/tests/test_crud.py
+++ b/backend/apps/product/tests/test_crud.py
@@ -1,0 +1,80 @@
+import random
+import string
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.product.models import Product
+from apps.project.models import Project, ProjectUser
+
+
+class ProductCRUDTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.User = get_user_model()
+        random_number = "".join(random.choices(string.digits, k=4))
+        email = f"owner_{random_number}@example.com"
+        self.user = self.User.objects.create_user(
+            email=email,
+            name="Owner",
+            password="pass1234",
+        )
+        self.project = Project.objects.create(name="Project CRUD")
+        ProjectUser.objects.create(
+            project=self.project,
+            user=self.user,
+            role=ProjectUser.PROJECT_USER_ROLE_OWNER,
+        )
+        self.user.currently_selected_project = self.project
+        self.user.save()
+        self.client.force_authenticate(user=self.user)
+
+    def test_full_crud_flow(self):
+        create_url = reverse("product_list_create")
+        payload = {"project": self.project.id, "title": "Prod", "description": "Desc"}
+        res = self.client.post(create_url, payload)
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        product_id = res.data["id"]
+
+        list_res = self.client.get(create_url)
+        self.assertEqual(list_res.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(list_res.data), 1)
+
+        detail_url = reverse("product_detail", args=[product_id])
+        detail_res = self.client.get(detail_url)
+        self.assertEqual(detail_res.status_code, status.HTTP_200_OK)
+        self.assertEqual(detail_res.data["title"], "Prod")
+
+        update_payload = {"title": "Updated"}
+        update_res = self.client.put(detail_url, update_payload)
+        self.assertEqual(update_res.status_code, status.HTTP_200_OK)
+        self.assertEqual(update_res.data["title"], "Updated")
+
+        delete_res = self.client.delete(detail_url)
+        self.assertEqual(delete_res.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Product.objects.filter(id=product_id).exists())
+
+    def test_viewer_cannot_modify(self):
+        # change role to viewer
+        pu = ProjectUser.objects.get(project=self.project, user=self.user)
+        pu.role = ProjectUser.PROJECT_USER_ROLE_VIEWER
+        pu.save()
+
+        url = reverse("product_list_create")
+        payload = {"project": self.project.id, "title": "Prod", "description": ""}
+        res = self.client.post(url, payload)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+        product = Product.objects.create(
+            project=self.project,
+            title="Prod1",
+            description="",
+        )
+        detail_url = reverse("product_detail", args=[product.id])
+        res = self.client.put(detail_url, {"title": "x"})
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+        res = self.client.delete(detail_url)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/apps/product/tests/test_models.py
+++ b/backend/apps/product/tests/test_models.py
@@ -1,0 +1,71 @@
+import datetime
+from decimal import Decimal
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from apps.product.models import Product, ProductImage, ProductImpressions, ProductSale
+from apps.project.models import Project
+
+
+class ProductModelTests(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Proj")
+        self.product = Product.objects.create(
+            project=self.project,
+            title="Prod",
+            description="",
+        )
+
+    def test_total_royalty_earnings(self):
+        ProductSale.objects.create(
+            product=self.product,
+            type="purchase",
+            unit_price=Decimal("10.00"),
+            unit_price_currency="USD",
+            quantity=1,
+            royalty_amount=Decimal("4.00"),
+            royalty_currency="USD",
+            period_start=datetime.date(2024, 1, 1),
+            period_end=datetime.date(2024, 1, 31),
+        )
+        ProductSale.objects.create(
+            product=self.product,
+            type="purchase",
+            unit_price=Decimal("5.00"),
+            unit_price_currency="USD",
+            quantity=1,
+            royalty_amount=Decimal("2.00"),
+            royalty_currency="USD",
+            period_start=datetime.date(2024, 2, 1),
+            period_end=datetime.date(2024, 2, 28),
+            is_refund=True,
+        )
+        total = self.product.total_royalty_earnings()
+        self.assertEqual(total, Decimal("4.00"))
+        jan_total = self.product.total_royalty_earnings(
+            datetime.date(2024, 1, 1),
+            datetime.date(2024, 1, 31),
+        )
+        self.assertEqual(jan_total, Decimal("4.00"))
+
+    def test_impressions_helpers(self):
+        ProductImpressions.objects.create(
+            product=self.product,
+            impressions=100,
+            ecpm=Decimal("2.00"),
+            period_start=datetime.date(2024, 1, 1),
+            period_end=datetime.date(2024, 1, 31),
+        )
+        total_impr = self.product.total_impressions()
+        revenue = self.product.impressions_revenue()
+        self.assertEqual(total_impr, 100)
+        self.assertEqual(revenue, Decimal("0"))
+
+    def test_product_image_auto_assign(self):
+        file_name = f"{self.project.id}_{self.product.id}.jpg"
+        uploaded = SimpleUploadedFile(file_name, b"img", content_type="image/jpeg")
+        image = ProductImage.objects.create(image=uploaded)
+        image.refresh_from_db()
+        self.assertEqual(image.project, self.project)
+        self.assertEqual(image.product, self.product)


### PR DESCRIPTION
## Summary
- create tests for product CRUD operations and permission checks
- add admin panel permission tests
- test Product model helper methods

## Testing
- `ruff check apps/admin_panel/tests/test_views.py apps/product/tests/test_crud.py apps/product/tests/test_models.py`
- `python manage.py test apps.admin_panel.tests apps.product.tests`

------
https://chatgpt.com/codex/tasks/task_e_6883de5899f48322a1996aa9faf34b23