### PR TITLE
[docs] document memcached usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ DJANGO_SECRET_KEY=
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=*
 
+# Caching
+USE_MEMCACHED=True # Set to 'False' to disable Memcached and use local memory cache
+CACHE_LOCATION=127.0.0.1:11211
+
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For a visual overview of these components see
 - Git
 - Node.js 16+ (for local development)
 - Python 3.11+ (for local development)
+- Memcached 1.6+ (for caching)
 
 ### Installation
 
@@ -105,6 +106,9 @@ For a visual overview of these components see
    # Production environment
    docker-compose -f production.yml up --build
    ```
+   A running Memcached instance is required. Add a `memcached` service to your
+   Docker Compose file or install Memcached locally and set `CACHE_LOCATION` in
+   your `.env`.
    If you want to run the services directly on your machine without Docker,
    follow the steps in
    [Running RoyaltyX Without Docker](documentation/NON_DOCKER_SETUP.md).
@@ -223,6 +227,9 @@ SERVER_EMAIL=your-email@gmail.com
 # Other services
 OPENAI_API_KEY=
 CELERY_BROKER_URL=redis://redis:6379/0
+# Caching
+USE_MEMCACHED=True
+CACHE_LOCATION=127.0.0.1:11211
 LOG_LEVEL=INFO
 ```
 
@@ -428,6 +435,8 @@ RoyaltyX/
    ```bash
    docker-compose -f production.yml up -d --build
    ```
+   Ensure a `memcached` service is running or accessible and that
+   `CACHE_LOCATION` in `.env.production` points to it.
 
 3. **Set up SSL certificate**
    ```bash

--- a/backend/royaltyx/settings.py
+++ b/backend/royaltyx/settings.py
@@ -86,12 +86,20 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
-        "LOCATION": "127.0.0.1:11211",
+USE_MEMCACHED = os.getenv("USE_MEMCACHED", "True") == "True"
+CACHE_LOCATION = os.getenv("CACHE_LOCATION", "127.0.0.1:11211")
+
+if USE_MEMCACHED:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "LOCATION": CACHE_LOCATION,
+        }
     }
-}
+else:
+    CACHES = {
+        "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
+    }
 
 ROOT_URLCONF = "royaltyx.urls"
 


### PR DESCRIPTION
## Summary
- mention Memcached in prerequisites and Docker instructions
- add caching variables to README environment section
- explain how to enable/disable Memcached via `.env.example`
- support USE_MEMCACHED and CACHE_LOCATION in Django settings

## Testing
- `python manage.py migrate --noinput`
- `python manage.py test`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6883de60f5c88322aceba47294630778